### PR TITLE
Fix 'cannot create regular file` error on initial build

### DIFF
--- a/gen-artifacts.sh
+++ b/gen-artifacts.sh
@@ -16,7 +16,7 @@ if [ "$1" = "ios" ]; then
 elif [ "$1" = "android" ]; then
   # Build nebula for android
   make mobileNebula.aar
-  rm -rf ../android/app/src/main/libs/mobileNebula.aar
+  mkdir -p ../android/app/src/main/libs
   cp mobileNebula.aar ../android/app/src/main/libs/mobileNebula.aar
 
 else


### PR DESCRIPTION
If you've never built the project before the `android/app/src/main/libs`
directory doesn't exist, and so `./gen-artifacts.sh` errors out when run
in that case. This commit fixes `./gen-artifacts.sh` so that it makes
that directory before trying to move a file there. It also removes an
unnecessary `rm -rf` command.