### PR TITLE
Add logLocalTZ to app settings

### DIFF
--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -34,7 +34,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     List<Widget> colorSection = [];
+    List<Widget> logSection = [];
 
+    // System Color Configs
     colorSection.add(ConfigItem(
       label: Text('Use system colors'),
       labelWidth: 200,
@@ -63,10 +65,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
             )),
       ));
     }
-
-    List<Widget> items = [];
-    items.add(ConfigSection(children: colorSection));
-    items.add(ConfigItem(
+    // Log Configs
+    logSection.add(ConfigItem(
       label: Text('Wrap log output'),
       labelWidth: 200,
       content: Align(
@@ -81,6 +81,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           )),
     ));
+    logSection.add(ConfigItem(
+      label: Text('Use Local Time Zone'),
+      labelWidth: 200,
+      content: Align(
+          alignment: Alignment.centerRight,
+          child: Switch.adaptive(
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            value: settings.logLocalTZ,
+            onChanged: (value) {
+              setState(() {
+                settings.logLocalTZ = value;
+              });
+            },
+          )),
+    ));
+
+    List<Widget> items = [];
+    items.add(ConfigSection(children: colorSection));
+    items.add(ConfigSection(children: logSection));
     items.add(ConfigSection(children: [
       ConfigPageItem(
         label: Text('About'),

--- a/lib/screens/SiteLogsScreen.dart
+++ b/lib/screens/SiteLogsScreen.dart
@@ -103,8 +103,11 @@ class _SiteLogsScreenState extends State<SiteLogsScreen> {
   loadLogs() async {
     var file = File(widget.site.logFile);
     try {
-      final v = await file.readAsString();
+      String v = await file.readAsString();
 
+      if (settings.logLocalTZ) {
+        v = convertToLocalTZ(v);
+      }
       setState(() {
         logs = v;
       });
@@ -125,5 +128,13 @@ class _SiteLogsScreenState extends State<SiteLogsScreen> {
     } else {
       return BoxConstraints(minWidth: MediaQuery.of(context).size.width);
     }
+  }
+
+  convertToLocalTZ(String rawLog) {
+    rawLog = rawLog.replaceAllMapped(RegExp('time="(.*?)"'), (match) {
+      DateTime userDate = DateTime.parse(match.group(1));
+      return 'time="${userDate.toLocal().toIso8601String()}"';
+    });
+    return rawLog;
   }
 }

--- a/lib/services/settings.dart
+++ b/lib/services/settings.dart
@@ -38,6 +38,14 @@ class Settings {
     _set('logWrap', enabled);
   }
 
+  bool get logLocalTZ {
+    return _getBool('logLocalTZ', false);
+  }
+
+  set logLocalTZ(bool enabled) {
+    _set('logLocalTZ', enabled);
+  }
+
   String _getString(String key, String defaultValue) {
     final val = _settings[key];
     if (val is String) {


### PR DESCRIPTION
The default log timestamp is in UTC, this commit allows the user to
convert the log timestamps to their own timezone.

When approaching this problem I originally considered allowing the user
to set any timezone offset of their choice. This would require some
alignment between the device and client that was feeling cumbersome.

In the end we decided to keep things relatively simple and just allow a
simple toggle to convert log entries upon reading the logfile on the
device.

The default log timestamp emitted by the client remains UTC/Zulu

Advances #2
Closes #8