### PR TITLE
Fix state when connection toggle is tapped twice

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -45,9 +45,14 @@ class NebulaVpnService : VpnService() {
 
         val path = intent?.getStringExtra("path")
         val id = intent?.getStringExtra("id")
-        
+
         if (running) {
-            announceExit(id, "Trying to run nebula but it is already running")
+            // if the UI triggers this twice, check if we are already running the requested site. if not, return an error.
+            // otherwise, just ignore the request since we handled it the first time.
+            if (site!!.id != id) {
+                announceExit(id, "Trying to run nebula but it is already running")
+            }
+
             //TODO: can we signal failure?
             return super.onStartCommand(intent, flags, startId)
         }


### PR DESCRIPTION
Fixes #15. When tapping the toggle in rapid succession,
`NebulaVpnService.onStartCommand` is called twice, in serial.  This
method includes logic to show an error to the user if they somehow
attempt to connect to a service while already connected.

However, this method of showing an error message (calling
`announceExit`) sends a signal to `MainActivity` telling it the service
has exited, and that it should set the UI state to "Disconnected." It
does not actually disconnect the service at this point, resulting in a
state mismatch in which you cannot actually disconnect the service.

The solution in this commit is to remove this signalling and simply
return out of `onStartCommand` to avoid processing the start request
twice.

Another potential solution is to call `sendSimple(MSG_IS_RUNNING, 1)`
before returning, which would ensure that the UI is synchronized with
the service state at this point, however I have no reason to believe it
could get out of sync aside from the processing delay.