### PR TITLE
Add ability to add DNS resolvers to a site

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -88,6 +88,11 @@ class NebulaVpnService : VpnService() {
             builder.addRoute(ipNet.network, ipNet.maskSize.toInt())
         }
 
+        // Add our dns resolvers
+        site!!.dnsResolvers.forEach { dnsResolver ->
+            builder.addDnsServer(dnsResolver)
+        }
+
         val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         cm.allNetworks.forEach { network ->
             cm.getLinkProperties(network).dnsServers.forEach { builder.addDnsServer(it) }

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -134,6 +134,7 @@ class Site {
     val id: String
     val staticHostmap: HashMap<String, StaticHosts>
     val unsafeRoutes: List<UnsafeRoute>
+    val dnsResolvers: List<String>
     var cert: CertificateInfo? = null
     var ca: Array<CertificateInfo>
     val lhDuration: Int
@@ -165,6 +166,7 @@ class Site {
         id = incomingSite.id
         staticHostmap = incomingSite.staticHostmap
         unsafeRoutes = incomingSite.unsafeRoutes ?: ArrayList()
+        dnsResolvers = incomingSite.dnsResolvers ?: ArrayList()
         lhDuration = incomingSite.lhDuration
         port = incomingSite.port
         mtu = incomingSite.mtu ?: 1300
@@ -243,6 +245,7 @@ class IncomingSite(
     val id: String,
     val staticHostmap: HashMap<String, StaticHosts>,
     val unsafeRoutes: List<UnsafeRoute>?,
+    val dnsResolvers: List<String>?,
     val cert: String,
     val ca: String,
     val lhDuration: Int,

--- a/lib/models/Site.dart
+++ b/lib/models/Site.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:mobile_nebula/models/HostInfo.dart';
 import 'package:mobile_nebula/models/UnsafeRoute.dart';
+import 'package:mobile_nebula/models/IPAndPort.dart';
 import 'package:uuid/uuid.dart';
 import 'Certificate.dart';
 import 'StaticHosts.dart';
@@ -24,6 +25,7 @@ class Site {
   // static_host_map
   Map<String, StaticHost> staticHostmap;
   List<UnsafeRoute> unsafeRoutes;
+  List<String> dnsResolvers;
 
   // pki fields
   List<CertificateInfo> ca;
@@ -63,9 +65,11 @@ class Site {
       this.logFile,
       this.logVerbosity = 'info',
       errors,
-      unsafeRoutes})
+      unsafeRoutes,
+      dnsResolvers})
       : staticHostmap = staticHostmap ?? {},
         unsafeRoutes = unsafeRoutes ?? [],
+        dnsResolvers = dnsResolvers ?? [],
         errors = errors ?? [],
         ca = ca ?? [],
         id = id ?? uuid.v4();
@@ -87,6 +91,12 @@ class Site {
         unsafeRoutes.add(UnsafeRoute.fromJson(val));
       });
     }
+
+    List<dynamic> rawDNSResolvers = json['dnsResolvers'];
+    dnsResolvers = [];
+    (rawDNSResolvers ?? []).forEach((val) {
+      dnsResolvers.add(val);
+    });
 
     List<dynamic> rawCA = json['ca'];
     ca = [];
@@ -142,6 +152,7 @@ class Site {
       'id': id,
       'staticHostmap': staticHostmap,
       'unsafeRoutes': unsafeRoutes,
+      'dnsResolvers': dnsResolvers,
       'ca': ca?.map((cert) {
             return cert.rawCert;
           })?.join('\n') ??

--- a/lib/screens/siteConfig/AdvancedScreen.dart
+++ b/lib/screens/siteConfig/AdvancedScreen.dart
@@ -10,6 +10,7 @@ import 'package:mobile_nebula/components/config/ConfigSection.dart';
 import 'package:mobile_nebula/models/Site.dart';
 import 'package:mobile_nebula/models/UnsafeRoute.dart';
 import 'package:mobile_nebula/screens/siteConfig/CipherScreen.dart';
+import 'package:mobile_nebula/screens/siteConfig/DNSResolversScreen.dart';
 import 'package:mobile_nebula/screens/siteConfig/LogVerbosityScreen.dart';
 import 'package:mobile_nebula/screens/siteConfig/RenderedConfigScreen.dart';
 import 'package:mobile_nebula/services/utils.dart';
@@ -28,6 +29,7 @@ class Advanced {
   String verbosity;
   List<UnsafeRoute> unsafeRoutes;
   int mtu;
+  List<String> dnsResolvers;
 }
 
 class AdvancedScreen extends StatefulWidget {
@@ -52,6 +54,7 @@ class _AdvancedScreenState extends State<AdvancedScreen> {
     settings.verbosity = widget.site.logVerbosity;
     settings.unsafeRoutes = widget.site.unsafeRoutes;
     settings.mtu = widget.site.mtu;
+    settings.dnsResolvers = widget.site.dnsResolvers;
     super.initState();
   }
 
@@ -161,6 +164,25 @@ class _AdvancedScreenState extends State<AdvancedScreen> {
                       });
                     });
                   },
+              ),
+              ConfigPageItem(
+                label: Text('DNS Resolvers'),
+                labelWidth: 150,
+                content: Text(
+                    Utils.itemCountFormat(settings.dnsResolvers.length),
+                    textAlign: TextAlign.end),
+                onPressed: () {
+                  Utils.openPage(context, (context) {
+                    return DNSResolversScreen(
+                        dnsResolvers: settings.dnsResolvers,
+                        onSave: (dnsResolvers) {
+                          setState(() {
+                            settings.dnsResolvers = dnsResolvers;
+                            changed = true;
+                          });
+                        });
+                  });
+                },
               )
             ],
           ),

--- a/lib/screens/siteConfig/DNSResolverScreen.dart
+++ b/lib/screens/siteConfig/DNSResolverScreen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+import 'package:mobile_nebula/components/FormPage.dart';
+import 'package:mobile_nebula/components/IPFormField.dart';
+import 'package:mobile_nebula/components/config/ConfigItem.dart';
+import 'package:mobile_nebula/components/config/ConfigSection.dart';
+import 'package:mobile_nebula/services/utils.dart';
+
+class DNSResolverScreen extends StatefulWidget {
+  const DNSResolverScreen({Key key, this.dnsResolver, this.onDelete, @required this.onSave}) : super(key: key);
+
+  final String dnsResolver;
+  final ValueChanged<String> onSave;
+  final Function onDelete;
+
+  @override
+  _DNSResolverScreenState createState() => _DNSResolverScreenState();
+}
+
+class _DNSResolverScreenState extends State<DNSResolverScreen> {
+  String dnsResolver;
+  bool changed = false;
+
+  FocusNode dnsResolverFocus = FocusNode();
+
+  @override
+  void initState() {
+    dnsResolver = widget.dnsResolver;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FormPage(
+        title: widget.onDelete == null ? 'New DNS Resolver' : 'Edit DNS Resolver',
+        changed: changed,
+        onSave: _onSave,
+        child: Column(children: [
+          ConfigSection(children: <Widget>[
+            ConfigItem(
+                label: Text('Address'),
+                content: IPFormField(
+                    initialValue: dnsResolver,
+                    ipOnly: true,
+                    textInputAction: TextInputAction.next,
+                    focusNode: dnsResolverFocus,
+                    onSaved: (v) {
+                      dnsResolver = v.toString();
+                    })),
+          ]),
+          widget.onDelete != null
+              ? Padding(
+                  padding: EdgeInsets.only(top: 50, bottom: 10, left: 10, right: 10),
+                  child: SizedBox(
+                      width: double.infinity,
+                      child: PlatformButton(
+                        child: Text('Delete'),
+                        color: CupertinoColors.systemRed.resolveFrom(context),
+                        onPressed: () => Utils.confirmDelete(context, 'Delete DNS Resolver?', () {
+                          Navigator.of(context).pop();
+                          widget.onDelete();
+                        }),
+                      )))
+              : Container()
+        ]));
+  }
+
+  _onSave() {
+    Navigator.pop(context);
+    if (widget.onSave != null) {
+      widget.onSave(dnsResolver);
+    }
+  }
+}

--- a/lib/screens/siteConfig/DNSResolversScreen.dart
+++ b/lib/screens/siteConfig/DNSResolversScreen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
+import 'package:mobile_nebula/components/FormPage.dart';
+import 'package:mobile_nebula/components/config/ConfigButtonItem.dart';
+import 'package:mobile_nebula/components/config/ConfigPageItem.dart';
+import 'package:mobile_nebula/components/config/ConfigSection.dart';
+import 'package:mobile_nebula/screens/siteConfig/DNSResolverScreen.dart';
+import 'package:mobile_nebula/services/utils.dart';
+
+class DNSResolversScreen extends StatefulWidget {
+  const DNSResolversScreen(
+      {Key key, @required this.dnsResolvers, @required this.onSave})
+      : super(key: key);
+
+  final List<String> dnsResolvers;
+  final ValueChanged<List<String>> onSave;
+
+  @override
+  _DNSResolversScreenState createState() => _DNSResolversScreenState();
+}
+
+class _DNSResolversScreenState extends State<DNSResolversScreen> {
+  List<String> dnsResolvers = [];
+  bool changed = false;
+
+  @override
+  void initState() {
+    widget.dnsResolvers.forEach((dnsResolver) {
+      dnsResolvers.add(dnsResolver);
+    });
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FormPage(
+        title: 'DNS Resolvers',
+        changed: changed,
+        onSave: _onSave,
+        child: ConfigSection(
+          children: _build(),
+        ));
+  }
+
+  _onSave() {
+    Navigator.pop(context);
+    if (widget.onSave != null) {
+      widget.onSave(dnsResolvers);
+    }
+  }
+
+  List<Widget> _build() {
+    List<Widget> items = [];
+    for (var i=0; i<dnsResolvers.length;i++) {
+      final dnsResolver = dnsResolvers[i];
+      items.add(ConfigPageItem(
+        label: Text("Resolver"),
+        content: Text(dnsResolver, textAlign: TextAlign.end),
+        onPressed: () {
+          Utils.openPage(context, (context) {
+            return DNSResolverScreen(
+              dnsResolver: dnsResolver,
+              onSave: (dnsResolver) {
+                setState(() {
+                  changed = true;
+                  dnsResolvers[i] = dnsResolver;
+                });
+              },
+              onDelete: () {
+                setState(() {
+                  changed = true;
+                  dnsResolvers.removeAt(i);
+                });
+              },
+            );
+          });
+        },
+      ));
+    }
+
+    items.add(ConfigButtonItem(
+      content: Text('Add a new DNS resolver'),
+      onPressed: () {
+        Utils.openPage(context, (context) {
+          return DNSResolverScreen(
+              onSave: (dnsResolver) {
+                  setState(() {
+                      changed = true;
+                  });
+                  dnsResolvers.add(dnsResolver);
+              },
+          );
+        });
+      },
+    ));
+
+    return items;
+  }
+}

--- a/lib/screens/siteConfig/SiteConfigScreen.dart
+++ b/lib/screens/siteConfig/SiteConfigScreen.dart
@@ -219,6 +219,7 @@ class _SiteConfigScreenState extends State<SiteConfigScreen> {
                         site.port = settings.port;
                         site.logVerbosity = settings.verbosity;
                         site.unsafeRoutes = settings.unsafeRoutes;
+                        site.dnsResolvers = settings.dnsResolvers;
                         site.mtu = settings.mtu;
                       });
                     });

--- a/nebula/config.go
+++ b/nebula/config.go
@@ -137,6 +137,7 @@ type configTun struct {
 	MTU                *int                `yaml:"mtu,omitempty"`
 	Routes             []configRoute       `yaml:"routes"`
 	UnsafeRoutes       []configUnsafeRoute `yaml:"unsafe_routes"`
+	DNSResolvers       []string            `yaml:"dns_resolvers"`
 }
 
 type configRoute struct {

--- a/nebula/mobileNebula.go
+++ b/nebula/mobileNebula.go
@@ -102,6 +102,13 @@ func RenderConfig(configData string, key string) (string, error) {
 		}
 	}
 
+	if dnsResolvers, ok := d["dnsResolvers"].([]interface{}); ok {
+		config.Tun.DNSResolvers = make([]string, len(dnsResolvers))
+		for i, r := range dnsResolvers {
+			config.Tun.DNSResolvers[i] = r.(string)
+		}
+	}
+
 	finalConfig, err := yaml.Marshal(config)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
For most changes I simply copied whatever was being done for
`unsafeRoutes` and fitted it to work for dns resolvers.

TODO This does not currently work for iOS, only android, as I only have
an android device to test with.

Fixes #9 