### PR TITLE
Minor tweaks for a clean build

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
 - [`android-studio`](https://developer.android.com/studio)
 - [Enable NDK](https://developer.android.com/studio/projects/install-ndk) Check local.properties for current NDK version
 
+Downgrade flutter to a 1.x release (the following worked on an AUR install of `flutter`)
+
+```
+cd $(dirname $(readlink $(which flutter)))
+git checkout 1.22.6
+flutter doctor
+```
+
 Copy env.sh.example to env.sh and update your PATH variable to expose both flutter and go bin directories
 
   ```export PATH="$PATH:/path/to/go/bin:/path/to/flutter/bin```

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -66,6 +66,7 @@ android {
 
             // We are disabling minification and proguard because it wrecks the crypto for storing keys
             // Ideally we would turn these on. We had issues with gson as well but resolved those with proguardFiles
+            shrinkResources false
             minifyEnabled false
             useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/gen-artifacts.sh
+++ b/gen-artifacts.sh
@@ -16,6 +16,7 @@ if [ "$1" = "ios" ]; then
 elif [ "$1" = "android" ]; then
   # Build nebula for android
   make mobileNebula.aar
+  mkdir -p ../android/app/src/main/libs
   rm -rf ../android/app/src/main/libs/mobileNebula.aar
   cp mobileNebula.aar ../android/app/src/main/libs/mobileNebula.aar
 


### PR DESCRIPTION
- Updated README with some maybe-helpful instructions for downgrading
  flutter to a version that will build the project
- Added a step to create a missing directory to the Gradle build
  (otherwise the build fails)
- Set `shrinkResources false` - otherwise you get an error that you
  can't shrink resources unless you also enable minifying