### PR TITLE
Rework ios ipc

### DIFF
--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -1,6 +1,7 @@
 import NetworkExtension
 import MobileNebula
 import os.log
+import SwiftyJSON
 
 class PacketTunnelProvider: NEPacketTunnelProvider {
     private var networkMonitor: NWPathMonitor?
@@ -15,7 +16,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     // This is the system completionHandler, only set when we expect the UI to ask us to actually start so that errors can flow back to the UI
     private var startCompleter: ((Error?) -> Void)?
     
-    private func log(_ message: StaticString, _ args: CVarArg...) {
+    private func log(_ message: StaticString, _ args: Any...) {
         os_log(message, log: _log, args)
     }
     
@@ -194,7 +195,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                         
                     } else {
                         // Error response has
-                        completionHandler!(try? JSONEncoder().encode(IPCResponse.init(type: .error, message: .string(error!.localizedDescription))))
+                        completionHandler!(try? JSONEncoder().encode(IPCResponse.init(type: .error, message: JSON(error!.localizedDescription))))
                     }
                 }
             }
@@ -220,7 +221,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
         
         if (error != nil) {
-            completionHandler!(try? JSONEncoder().encode(IPCResponse.init(type: .error, message: JSON.string(error?.localizedDescription ?? "Unknown error"))))
+            completionHandler!(try? JSONEncoder().encode(IPCResponse.init(type: .error, message: JSON(error?.localizedDescription ?? "Unknown error"))))
         } else {
             completionHandler!(try? JSONEncoder().encode(IPCResponse.init(type: .success, message: data)))
         }
@@ -229,24 +230,24 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private func listHostmap(pending: Bool) -> (JSON?, Error?) {
         var err: NSError?
         let res = nebula!.listHostmap(pending, error: &err)
-        return (JSON.string(res), err)
+        return (JSON(res), err)
     }
     
-    private func getHostInfo(args: Dictionary<String, Any>) -> (JSON?, Error?) {
+    private func getHostInfo(args: JSON) -> (JSON?, Error?) {
         var err: NSError?
-        let res = nebula!.getHostInfo(byVpnIp: args["vpnIp"] as? String, pending: args["pending"] as! Bool, error: &err)
-        return (JSON.string(res), err)
+        let res = nebula!.getHostInfo(byVpnIp: args["vpnIp"].string, pending: args["pending"].boolValue, error: &err)
+        return (JSON(res), err)
     }
     
-    private func setRemoteForTunnel(args: Dictionary<String, Any>) -> (JSON?, Error?) {
+    private func setRemoteForTunnel(args: JSON) -> (JSON?, Error?) {
         var err: NSError?
-        let res = nebula!.setRemoteForTunnel(args["vpnIp"] as? String, addr: args["addr"] as? String, error: &err)
-        return (JSON.string(res), err)
+        let res = nebula!.setRemoteForTunnel(args["vpnIp"].string, addr: args["addr"].string, error: &err)
+        return (JSON(res), err)
     }
     
-    private func closeTunnel(args: Dictionary<String, Any>) -> (JSON?, Error?) {
-        let res = nebula!.closeTunnel(args["vpnIp"] as? String)
-        return (JSON.bool(res), nil)
+    private func closeTunnel(args: JSON) -> (JSON?, Error?) {
+        let res = nebula!.closeTunnel(args["vpnIp"].string)
+        return (JSON(res), nil)
     }
 }
 

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -1,102 +1,12 @@
 import NetworkExtension
 import MobileNebula
+import SwiftyJSON
 
 extension String: Error {}
 
 enum IPCResponseType: String, Codable {
     case error = "error"
     case success = "success"
-}
-
-// JSON extensions heavily influenced by https://github.com/zoul/generic-json-swift/blob/master/GenericJSON/JSON.swift
-
-enum JSON {
-    case string(String)
-    case number(Double)
-    case object([String:JSON])
-    case array([JSON])
-    case bool(Bool)
-    case null
-}
-
-extension JSON: Codable {
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-
-        switch self {
-        case let .array(array):
-            try container.encode(array)
-        case let .object(object):
-            try container.encode(object)
-        case let .string(string):
-            try container.encode(string)
-        case let .number(number):
-            try container.encode(number)
-        case let .bool(bool):
-            try container.encode(bool)
-        case .null:
-            try container.encodeNil()
-        }
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-
-        if let object = try? container.decode([String: JSON].self) {
-            self = .object(object)
-        } else if let array = try? container.decode([JSON].self) {
-            self = .array(array)
-        } else if let string = try? container.decode(String.self) {
-            self = .string(string)
-        } else if let bool = try? container.decode(Bool.self) {
-            self = .bool(bool)
-        } else if let number = try? container.decode(Double.self) {
-            self = .number(number)
-        } else if container.decodeNil() {
-            self = .null
-        } else {
-            throw DecodingError.dataCorrupted(
-                .init(codingPath: decoder.codingPath, debugDescription: "Invalid JSON value.")
-            )
-        }
-    }
-    
-    func any() -> Any? {
-        switch self {
-        case let .array(array):
-            return array
-        case let .object(object):
-            return object
-        case let .string(string):
-            return string
-        case let .number(number):
-            return number
-        case let .bool(bool):
-            return bool
-        case .null:
-            return nil
-        }
-    }
-}
-
-
-extension JSON: CustomDebugStringConvertible {
-    public var debugDescription: String {
-        switch self {
-        case .string(let str):
-            return str.debugDescription
-        case .number(let num):
-            return num.debugDescription
-        case .bool(let bool):
-            return bool.description
-        case .null:
-            return "null"
-        default:
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted]
-            return try! String(data: encoder.encode(self), encoding: .utf8)!
-        }
-    }
 }
 
 class IPCResponse: Codable {
@@ -112,9 +22,9 @@ class IPCResponse: Codable {
 
 class IPCRequest: Codable {
     var command: String
-    var arguments: Dictionary<String, String>?
+    var arguments: JSON?
     
-    init(command: String, arguments: Dictionary<String, String>?) {
+    init(command: String, arguments: JSON?) {
         self.command = command
         self.arguments = arguments
     }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -30,14 +30,14 @@ flutter_ios_podfile_setup
 target 'Runner' do
   use_frameworks!
   use_modular_headers!
-
+  
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'MMWormhole', '~> 2.0.0'
+  pod 'SwiftyJSON', '~> 5.0'
 end
 
 target 'NebulaNetworkExtension' do
-    use_frameworks!
-    pod 'MMWormhole', '~> 2.0.0'
+  use_frameworks!
+  pod 'SwiftyJSON', '~> 5.0'
 end
 
 post_install do |installer|

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -39,9 +39,6 @@ PODS:
     - Flutter
   - FLAnimatedImage (1.0.12)
   - Flutter (1.0.0)
-  - MMWormhole (2.0.0):
-    - MMWormhole/Core (= 2.0.0)
-  - MMWormhole/Core (2.0.0)
   - MTBBarcodeScanner (5.0.11)
   - package_info (0.0.1):
     - Flutter
@@ -54,6 +51,7 @@ PODS:
     - FLAnimatedImage (>= 1.0.11)
     - SDWebImage/Core (~> 5.6)
   - SwiftProtobuf (1.8.0)
+  - SwiftyJSON (5.0.1)
   - url_launcher (0.0.1):
     - Flutter
 
@@ -61,9 +59,9 @@ DEPENDENCIES:
   - barcode_scan (from `.symlinks/plugins/barcode_scan/ios`)
   - file_picker (from `.symlinks/plugins/file_picker/ios`)
   - Flutter (from `Flutter`)
-  - MMWormhole (~> 2.0.0)
   - package_info (from `.symlinks/plugins/package_info/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
+  - SwiftyJSON (~> 5.0)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
 SPEC REPOS:
@@ -71,11 +69,11 @@ SPEC REPOS:
     - DKImagePickerController
     - DKPhotoGallery
     - FLAnimatedImage
-    - MMWormhole
     - MTBBarcodeScanner
     - SDWebImage
     - SDWebImageFLPlugin
     - SwiftProtobuf
+    - SwiftyJSON
 
 EXTERNAL SOURCES:
   barcode_scan:
@@ -98,15 +96,15 @@ SPEC CHECKSUMS:
   file_picker: 3e6c3790de664ccf9b882732d9db5eaf6b8d4eb1
   FLAnimatedImage: 4a0b56255d9b05f18b6dd7ee06871be5d3b89e31
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
-  MMWormhole: 0cd3fd35a9118b2e2d762b499f54eeaace0be791
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   SDWebImage: 84000f962cbfa70c07f19d2234cbfcf5d779b5dc
   SDWebImageFLPlugin: 6c2295fb1242d44467c6c87dc5db6b0a13228fd8
   SwiftProtobuf: 2cbd9409689b7df170d82a92a33443c8e3e14a70
+  SwiftyJSON: 2f33a42c6fbc52764d96f13368585094bfd8aa5e
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
-PODFILE CHECKSUM: e8d4fb1ed5b0713de2623a28dfae2585e15c0d00
+PODFILE CHECKSUM: 87c61886589bcc4c3c709db9ee22a607d81c4861
 
 COCOAPODS: 1.10.1

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -23,10 +23,10 @@
 		43AD63F424EB3802000FB47E /* Share.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AD63F324EB3802000FB47E /* Share.swift */; };
 		4CF2F06A02A63B862C9F6F03 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 384887B4785D38431E800D3A /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
-		78E28476711DF3A9D186C429 /* Pods_NebulaNetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EFDD7248CAE56012FE2608C /* Pods_NebulaNetworkExtension.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		E91B9DAD4A83866D0AF1DAE1 /* Pods_NebulaNetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C0A96949A0B117C4ACE752C /* Pods_NebulaNetworkExtension.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,11 +64,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		137DCAF9F91CD7AF6438A183 /* Pods-NebulaNetworkExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NebulaNetworkExtension.debug.xcconfig"; path = "Target Support Files/Pods-NebulaNetworkExtension/Pods-NebulaNetworkExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		384887B4785D38431E800D3A /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		41927814D2E140A347A01067 /* Pods-NebulaNetworkExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NebulaNetworkExtension.debug.xcconfig"; path = "Target Support Files/Pods-NebulaNetworkExtension/Pods-NebulaNetworkExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		437F72582469AAC500A0C4B9 /* Site.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Site.swift; sourceTree = "<group>"; };
 		437F725C2469AC5700A0C4B9 /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		43871C9A2444DD39004F9075 /* MobileNebula.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = MobileNebula.framework; sourceTree = "<group>"; };
@@ -84,12 +84,14 @@
 		43B66ECC245A146300B18C36 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		43B828DA249C08DC00CA229C /* MMWormhole.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MMWormhole.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		43E9BBD0251450C5000BFB8C /* MMWormhole.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MMWormhole.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		53C42258A2092B55937DCF53 /* Pods-NebulaNetworkExtension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NebulaNetworkExtension.profile.xcconfig"; path = "Target Support Files/Pods-NebulaNetworkExtension/Pods-NebulaNetworkExtension.profile.xcconfig"; sourceTree = "<group>"; };
+		5C0A96949A0B117C4ACE752C /* Pods_NebulaNetworkExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NebulaNetworkExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E7A71D8C71BF965D042667D /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8E4961BE2F06B97C8C693530 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
-		8EFDD7248CAE56012FE2608C /* Pods_NebulaNetworkExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NebulaNetworkExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9169E2D0D49FAF5172A6E7B8 /* Pods-NebulaNetworkExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NebulaNetworkExtension.release.xcconfig"; path = "Target Support Files/Pods-NebulaNetworkExtension/Pods-NebulaNetworkExtension.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -98,8 +100,6 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C2D5198CF6975BF93E8A6F93 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		E346A0DC829EBFB76D581AAD /* Pods-NebulaNetworkExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NebulaNetworkExtension.release.xcconfig"; path = "Target Support Files/Pods-NebulaNetworkExtension/Pods-NebulaNetworkExtension.release.xcconfig"; sourceTree = "<group>"; };
-		FA7B03A7901388BC39329544 /* Pods-NebulaNetworkExtension.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NebulaNetworkExtension.profile.xcconfig"; path = "Target Support Files/Pods-NebulaNetworkExtension/Pods-NebulaNetworkExtension.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,7 +109,7 @@
 			files = (
 				43AA89622444DAA500EDC39C /* NetworkExtension.framework in Frameworks */,
 				43871C9B2444DD39004F9075 /* MobileNebula.framework in Frameworks */,
-				78E28476711DF3A9D186C429 /* Pods_NebulaNetworkExtension.framework in Frameworks */,
+				E91B9DAD4A83866D0AF1DAE1 /* Pods_NebulaNetworkExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -135,7 +135,7 @@
 				43B66ECA245A0C8400B18C36 /* CoreFoundation.framework */,
 				43AA894E2444D8BC00EDC39C /* NetworkExtension.framework */,
 				384887B4785D38431E800D3A /* Pods_Runner.framework */,
-				8EFDD7248CAE56012FE2608C /* Pods_NebulaNetworkExtension.framework */,
+				5C0A96949A0B117C4ACE752C /* Pods_NebulaNetworkExtension.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -217,9 +217,9 @@
 				C2D5198CF6975BF93E8A6F93 /* Pods-Runner.debug.xcconfig */,
 				6E7A71D8C71BF965D042667D /* Pods-Runner.release.xcconfig */,
 				8E4961BE2F06B97C8C693530 /* Pods-Runner.profile.xcconfig */,
-				137DCAF9F91CD7AF6438A183 /* Pods-NebulaNetworkExtension.debug.xcconfig */,
-				E346A0DC829EBFB76D581AAD /* Pods-NebulaNetworkExtension.release.xcconfig */,
-				FA7B03A7901388BC39329544 /* Pods-NebulaNetworkExtension.profile.xcconfig */,
+				41927814D2E140A347A01067 /* Pods-NebulaNetworkExtension.debug.xcconfig */,
+				9169E2D0D49FAF5172A6E7B8 /* Pods-NebulaNetworkExtension.release.xcconfig */,
+				53C42258A2092B55937DCF53 /* Pods-NebulaNetworkExtension.profile.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -231,7 +231,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 43AA895D2444DA6500EDC39C /* Build configuration list for PBXNativeTarget "NebulaNetworkExtension" */;
 			buildPhases = (
-				D39D78EE128AD494ACEF8DC0 /* [CP] Check Pods Manifest.lock */,
+				2C0A52E24BC9F327251CBAD2 /* [CP] Check Pods Manifest.lock */,
 				43AA89632444DAD100EDC39C /* ShellScript */,
 				43AA89502444DA6500EDC39C /* Sources */,
 				43AA89512444DA6500EDC39C /* Frameworks */,
@@ -343,11 +343,11 @@
 				"${BUILT_PRODUCTS_DIR}/DKImagePickerController/DKImagePickerController.framework",
 				"${BUILT_PRODUCTS_DIR}/DKPhotoGallery/DKPhotoGallery.framework",
 				"${BUILT_PRODUCTS_DIR}/FLAnimatedImage/FLAnimatedImage.framework",
-				"${BUILT_PRODUCTS_DIR}/MMWormhole/MMWormhole.framework",
 				"${BUILT_PRODUCTS_DIR}/MTBBarcodeScanner/MTBBarcodeScanner.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
 				"${BUILT_PRODUCTS_DIR}/SDWebImageFLPlugin/SDWebImageFLPlugin.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftProtobuf/SwiftProtobuf.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 				"${BUILT_PRODUCTS_DIR}/barcode_scan/barcode_scan.framework",
 				"${BUILT_PRODUCTS_DIR}/file_picker/file_picker.framework",
 				"${BUILT_PRODUCTS_DIR}/package_info/package_info.framework",
@@ -359,11 +359,11 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DKImagePickerController.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DKPhotoGallery.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLAnimatedImage.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MMWormhole.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MTBBarcodeScanner.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageFLPlugin.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftProtobuf.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/barcode_scan.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/file_picker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info.framework",
@@ -373,6 +373,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2C0A52E24BC9F327251CBAD2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-NebulaNetworkExtension-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
@@ -420,28 +442,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
-		};
-		D39D78EE128AD494ACEF8DC0 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-NebulaNetworkExtension-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
 		};
 		FF0E0EB9A684F086443A8FBA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -579,7 +579,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 576H3XS7FP;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -605,7 +605,7 @@
 		};
 		43AA895E2444DA6500EDC39C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 137DCAF9F91CD7AF6438A183 /* Pods-NebulaNetworkExtension.debug.xcconfig */;
+			baseConfigurationReference = 41927814D2E140A347A01067 /* Pods-NebulaNetworkExtension.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -614,7 +614,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = NebulaNetworkExtension/NebulaNetworkExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 576H3XS7FP;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -641,7 +641,7 @@
 		};
 		43AA895F2444DA6500EDC39C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E346A0DC829EBFB76D581AAD /* Pods-NebulaNetworkExtension.release.xcconfig */;
+			baseConfigurationReference = 9169E2D0D49FAF5172A6E7B8 /* Pods-NebulaNetworkExtension.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -650,7 +650,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = NebulaNetworkExtension/NebulaNetworkExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 576H3XS7FP;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -674,7 +674,7 @@
 		};
 		43AA89602444DA6500EDC39C /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FA7B03A7901388BC39329544 /* Pods-NebulaNetworkExtension.profile.xcconfig */;
+			baseConfigurationReference = 53C42258A2092B55937DCF53 /* Pods-NebulaNetworkExtension.profile.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -683,7 +683,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = NebulaNetworkExtension/NebulaNetworkExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 576H3XS7FP;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -819,7 +819,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 576H3XS7FP;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -852,7 +852,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 11;
 				DEVELOPMENT_TEAM = 576H3XS7FP;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/lib/models/Site.dart
+++ b/lib/models/Site.dart
@@ -185,8 +185,7 @@ class Site {
     try {
       await platform.invokeMethod("startSite", <String, String>{"id": id});
     } on PlatformException catch (err) {
-      //TODO: fix this message
-      throw err.details ?? err.message ?? err.toString();
+      throw err.message ?? err.toString();
     } catch (err) {
       throw err.toString();
     }

--- a/lib/screens/SiteDetailScreen.dart
+++ b/lib/screens/SiteDetailScreen.dart
@@ -89,7 +89,7 @@ class _SiteDetailScreenState extends State<SiteDetailScreen> {
         }),
         refreshController: refreshController,
         onRefresh: () async {
-          if (site.connected) {
+          if (site.connected && site.status == "Connected") {
             await _listHostmap();
           }
           refreshController.refreshCompleted();

--- a/lib/screens/SiteDetailScreen.dart
+++ b/lib/screens/SiteDetailScreen.dart
@@ -50,7 +50,6 @@ class _SiteDetailScreenState extends State<SiteDetailScreen> {
     }
 
     onChange = site.onChange().listen((_) {
-      setState(() {});
       if (lastState != site.connected) {
         //TODO: connected is set before the nebula object exists leading to a crash race, waiting for "Connected" status is a gross hack but keeps it alive
         if (site.status == 'Connected') {
@@ -62,6 +61,8 @@ class _SiteDetailScreenState extends State<SiteDetailScreen> {
           pendingHosts = null;
         }
       }
+      setState(() {});
+
     }, onError: (err) {
       setState(() {});
       Utils.popError(context, "Error", err);


### PR DESCRIPTION
I set out to fix the network gateway detection to not be so verbose and got frustrated with the ios ipc lossy behavior.

This change does two main things.
1. Tries to rebind less by understanding what changed and not rebinding when nothing changed. This is better than before but we can likely improve further.
2. Replaced `MMWormhole`, a file based IPC mechanism with the `NETunnelProvider.handleAppMessage`, these calls can only be triggered by the UI which matches how everything but starting the VPN works before.

The biggest change is the final point, we want to receive startup errors but ios does not give us access to them and we have no way to call the UI directly from the vpn service. So, when the UI asks the system to start we send an option that our vpn code understands as "wait for another start command", this command will come from the UI and has a callback we can use to return success/failure. The actual start command is actually triggered by the system when it notifies us that our vpn service has transitioned from `disconnected` to `connecting`