### PR TITLE
Let Android install debug & release APKs side-by-side

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ lib/generated_plugin_registrant.dart
 /ios/Flutter/.last_build_id
 /local.properties
 /.gradle/
+*.keystore

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -70,6 +70,12 @@ android {
             minifyEnabled false
             useProguard false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+
+            resValue 'string', 'app_name', '"Nebula"'
+        }
+        debug {
+            resValue 'string', 'app_name', '"Nebula-DEBUG"'
+            applicationIdSuffix '.debug'
         }
     }
 }

--- a/android/app/src/debug/res/values/ic_launcher_background.xml
+++ b/android/app/src/debug/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#f2c10d</color>
+</resources>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <application
         android:name="io.flutter.app.FlutterApplication"
-        android:label="Nebula"
+        android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher">
         <service android:name=".NebulaVpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"


### PR DESCRIPTION
This makes it possible to install the debug APK without uninstalling the release APK (and thereby losing all of your site configurations.) It also tweaks the names and launcher icons slightly for the debug release.

I also added a gitignore rule to ignore any `*.keystore` files, but can pull that out of the diff if desired.

![image](https://user-images.githubusercontent.com/440033/116604339-fd02aa00-a8fb-11eb-80fc-fc9a49b990cb.png)