### PR TITLE
Unregister network callback on stop (Android)

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -39,6 +39,7 @@ class NebulaVpnService : VpnService() {
     private var nebula: mobileNebula.Nebula? = null
     private var vpnInterface: ParcelFileDescriptor? = null
     private var didSleep = false
+    private var networkCallback: NetworkCallback = NetworkCallback();
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.getStringExtra("COMMAND") == "STOP") {
@@ -123,19 +124,26 @@ class NebulaVpnService : VpnService() {
         val builder = NetworkRequest.Builder()
         builder.addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
 
-        connectivityManager.registerNetworkCallback(builder.build(),
-                object : ConnectivityManager.NetworkCallback () {
-                    override fun onAvailable(network: Network?) {
-                        super.onAvailable(network)
-                        nebula!!.rebind("network change")
-                    }
-
-                    override fun onLost(network: Network?) {
-                        super.onLost(network)
-                        nebula!!.rebind("network change")
-                    }
-                })
+        connectivityManager.registerNetworkCallback(builder.build(), networkCallback)
     }
+
+    private fun unregisterNetworkCallback() {
+        val connectivityManager = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+    }
+
+    inner class NetworkCallback() : ConnectivityManager.NetworkCallback () {
+        override fun onAvailable(network: Network?) {
+            super.onAvailable(network)
+            nebula!!.rebind("network change")
+        }
+
+        override fun onLost(network: Network?) {
+            super.onLost(network)
+            nebula!!.rebind("network change")
+        }
+    }
+
 
     private fun registerSleep() {
         val receiver: BroadcastReceiver = object : BroadcastReceiver() {
@@ -158,6 +166,7 @@ class NebulaVpnService : VpnService() {
     }
 
     private fun stopVpn() {
+        unregisterNetworkCallback()
         nebula?.stop()
         vpnInterface?.close()
         running = false


### PR DESCRIPTION
Previously when `stopVpn()` was called, it was possible for the network
change callback to fire while we were in the middle of shutting down.
This commit unregisters the network change callback before telling
Nebula to shutdown.