### PR TITLE
Remove setting dns as it seems to be unnecessary

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -97,11 +97,6 @@ class NebulaVpnService : VpnService() {
             builder.addRoute(ipNet.network, ipNet.maskSize.toInt())
         }
 
-        val cm = getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        cm.allNetworks.forEach { network ->
-            cm.getLinkProperties(network).dnsServers.forEach { builder.addDnsServer(it) }
-        }
-
         try {
             vpnInterface = builder.establish()
             nebula = mobileNebula.MobileNebula.newNebula(site!!.config, site!!.getKey(this), site!!.logFile, vpnInterface!!.fd.toLong())


### PR DESCRIPTION
@JohnMaguire was having issues with DNS when changing networks and it got traced back to here. Properly supporting DNS over nebula requires a certificate that allows the subnet and then it can be configured via unsafe routes.