### PR TITLE
Fix DNS over mobile networks on Android

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.net.*
 import android.os.*
+import android.system.OsConstants
 import android.util.Log
 import androidx.annotation.RequiresApi
 import mobileNebula.CIDR
@@ -90,6 +91,8 @@ class NebulaVpnService : VpnService() {
                 .addRoute(ipNet.network, ipNet.maskSize.toInt())
                 .setMtu(site!!.mtu)
                 .setSession(TAG)
+                .allowFamily(OsConstants.AF_INET)
+                .allowFamily(OsConstants.AF_INET6);
 
         // Add our unsafe routes
         site!!.unsafeRoutes.forEach { unsafeRoute ->


### PR DESCRIPTION
I think this closes the loop on DNS issues I was experiencing.
Previously, after starting Nebula, DNS would work until you switched
networks (e.g. from mobile to WiFi or vice-versa). This was fixed by
removing some explicit DNS server sets in commit
a283bf8010efdfa8798a56cd314b01cbe06e5c2c. This casued DNS to work in
`adb shell` even after toggling networks.

However, it did not actually fix the problem for Android applications.
The new behavior is that they would work while on WiFi, but fail on a
mobile network.

To quote Android docs:

> Allows traffic from the specified address family. By default, if no
> address, route or DNS server of a specific family (IPv4 or IPv6) is
> added to this VPN, then all outgoing traffic of that family is blocked.
> If any address, route or DNS server is added, that family is allowed.
> This method allows an address family to be unblocked even without adding
> an address, route or DNS server of that family. Traffic of that family
> will then typically fall-through to the underlying network if it's
> supported. family must be either AF_INET (for IPv4) or AF_INET6 (for
> IPv6). IllegalArgumentException is thrown if it's neither.

In my case, my home network supports only IPv4 while my mobile network
uses DNS over IPv6. Since my Nebula routes are IPv4-only, IPv6 traffic
stopped working, and DNS requests failed.