### PR TITLE
Better certificate import handling

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -49,6 +49,7 @@ class MainActivity: FlutterActivity() {
                 "nebula.parseCerts" -> nebulaParseCerts(call, result)
                 "nebula.generateKeyPair" -> nebulaGenerateKeyPair(result)
                 "nebula.renderConfig" -> nebulaRenderConfig(call, result)
+                "nebula.verifyCertAndKey" -> nebulaVerifyCertAndKey(call, result)
 
                 "listSites" -> listSites(result)
                 "deleteSite" -> deleteSite(call, result)
@@ -102,6 +103,25 @@ class MainActivity: FlutterActivity() {
         val config = call.arguments as String
         val yaml = mobileNebula.MobileNebula.renderConfig(config, "<hidden>")
         return result.success(yaml)
+    }
+
+    private fun nebulaVerifyCertAndKey(call: MethodCall, result: MethodChannel.Result) {
+        val cert = call.argument<String>("cert")
+        if (cert == "") {
+            return result.error("required_argument", "cert is a required argument", null)
+        }
+
+        val key = call.argument<String>("key")
+        if (key == "") {
+            return result.error("required_argument", "key is a required argument", null)
+        }
+
+        return try {
+            val json = mobileNebula.MobileNebula.verifyCertAndKey(cert, key)
+            result.success(json)
+        } catch (err: Exception) {
+            result.error("unhandled_error", err.message, null)
+        }
     }
 
     private fun listSites(result: MethodChannel.Result) {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -34,6 +34,7 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
             case "nebula.parseCerts": return self.nebulaParseCerts(call: call, result: result)
             case "nebula.generateKeyPair": return self.nebulaGenerateKeyPair(result: result)
             case "nebula.renderConfig": return self.nebulaRenderConfig(call: call, result: result)
+            case "nebula.verifyCertAndKey": return self.nebulaVerifyCertAndKey(call: call, result: result)
                 
             case "listSites": return self.listSites(result: result)
             case "deleteSite": return self.deleteSite(call: call, result: result)
@@ -69,6 +70,21 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
         }
         
         return result(json)
+    }
+    
+    func nebulaVerifyCertAndKey(call: FlutterMethodCall, result: FlutterResult) {
+        guard let args = call.arguments as? Dictionary<String, String> else { return result(NoArgumentsError()) }
+        guard let cert = args["cert"] else { return result(MissingArgumentError(message: "cert is a required argument")) }
+        guard let key = args["key"] else { return result(MissingArgumentError(message: "key is a required argument")) }
+        
+        var err: NSError?
+        var validd: ObjCBool = false
+        let valid = MobileNebulaVerifyCertAndKey(cert, key, &validd, &err)
+        if (err != nil) {  
+            return result(CallFailedError(message: "Error while verifying certificate and private key", details: err!.localizedDescription))
+        }
+        
+        return result(valid)
     }
     
     func nebulaGenerateKeyPair(result: FlutterResult) {

--- a/lib/components/config/ConfigTextItem.dart
+++ b/lib/components/config/ConfigTextItem.dart
@@ -5,10 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:mobile_nebula/components/SpecialTextField.dart';
 
 class ConfigTextItem extends StatelessWidget {
-  const ConfigTextItem({Key key, this.placeholder, this.controller}) : super(key: key);
+  const ConfigTextItem({Key key, this.placeholder, this.controller, this.style = const TextStyle(fontFamily: 'RobotoMono')}) : super(key: key);
 
   final String placeholder;
   final TextEditingController controller;
+  final TextStyle style;
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +20,7 @@ class ConfigTextItem extends StatelessWidget {
             minLines: 3,
             maxLines: 10,
             placeholder: placeholder,
-            style: TextStyle(fontFamily: 'RobotoMono'),
+            style: style,
             controller: controller));
   }
 }

--- a/lib/screens/siteConfig/CertificateDetailsScreen.dart
+++ b/lib/screens/siteConfig/CertificateDetailsScreen.dart
@@ -10,7 +10,7 @@ import 'package:mobile_nebula/services/utils.dart';
 
 /// Displays the details of a CertificateInfo object. Respects incomplete objects (missing validity or rawCert)
 class CertificateDetailsScreen extends StatefulWidget {
-  const CertificateDetailsScreen({Key key, this.certInfo, this.onDelete, this.onSave, this.onReplace})
+  const CertificateDetailsScreen({Key key, this.certInfo, this.onDelete, this.onSave, this.onReplace, this.pubKey, this.privKey})
       : super(key: key);
 
   final CertificateInfo certInfo;
@@ -23,6 +23,9 @@ class CertificateDetailsScreen extends StatefulWidget {
 
   // onReplace is used to install a new certificate over top of the old one
   final ValueChanged<CertificateResult> onReplace;
+
+  final String pubKey;
+  final String privKey;
 
   @override
   _CertificateDetailsScreenState createState() => _CertificateDetailsScreenState();
@@ -164,7 +167,7 @@ class _CertificateDetailsScreenState extends State<CertificateDetailsScreen> {
                       // Slam the page back to the top
                       controller.animateTo(0,
                           duration: const Duration(milliseconds: 10), curve: Curves.linearToEaseOut);
-                    });
+                    }, pubKey: widget.pubKey, privKey: widget.privKey, );
                   });
                 })));
   }

--- a/lib/services/utils.dart
+++ b/lib/services/utils.dart
@@ -83,7 +83,11 @@ class Utils {
 
   static Widget trailingSaveWidget(BuildContext context, Function onPressed) {
     return CupertinoButton(
-        child: Text('Save', style: TextStyle(fontWeight: FontWeight.bold)),
+        child: Text('Save', style: TextStyle(
+            fontWeight: FontWeight.bold,
+            //TODO: For some reason on android if inherit is the default of true the text color here turns to the background color
+            inherit: Platform.isIOS ? true : false
+        )),
         padding: Platform.isAndroid ? null : EdgeInsets.zero,
         onPressed: () => onPressed());
   }

--- a/nebula/mobileNebula.go
+++ b/nebula/mobileNebula.go
@@ -250,6 +250,20 @@ func x25519Keypair() ([]byte, []byte, error) {
 	return pubkey[:], privkey[:], nil
 }
 
-//func VerifyCertAndKey(cert string, key string) (string, error) {
-//
-//}
+func VerifyCertAndKey(rawCert string, pemPrivateKey string) (bool, error) {
+	rawKey, _, err := cert.UnmarshalX25519PrivateKey([]byte(pemPrivateKey))
+	if err != nil {
+		return false, fmt.Errorf("error while unmarshaling private key: %s", err)
+	}
+
+	nebulaCert, _, err := cert.UnmarshalNebulaCertificateFromPEM([]byte(rawCert))
+	if err != nil {
+		return false, fmt.Errorf("error while unmarshaling cert: %s", err)
+	}
+
+	if err = nebulaCert.VerifyPrivateKey(rawKey); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
1. Generates public and private key material up front so that navigating away from certificate import screen doesn't wipe out any work.
2. Allows private key import
3. Verifies public/private key match on load of the certificate in addition to at full site config save

closes #20 
closes #48 