### PR TITLE
Fix majority of Android Studio warnings

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,8 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "net.defined.mobile_nebula"
+
     compileSdkVersion 33
     ndkVersion flutter.ndkVersion
 
@@ -44,8 +46,8 @@ android {
 
     defaultConfig {
         applicationId "net.defined.mobile_nebula"
-        minSdkVersion 23 //flutter.minSdkVersion
-        targetSdkVersion 31 //flutter.targetSdkVersion
+        minSdkVersion 26 //flutter.minSdkVersion
+        targetSdkVersion 33 //flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -81,7 +83,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation "androidx.security:security-crypto:1.0.0"
     implementation "androidx.work:work-runtime-ktx:$workVersion"
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation "com.google.guava:guava:31.0.1-android"
     implementation project(':mobileNebula')
 

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.defined.mobile_nebula">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="net.defined.mobile_nebula">
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/APIClient.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/APIClient.kt
@@ -1,10 +1,9 @@
 package net.defined.mobile_nebula
 
 import android.content.Context
-import android.util.Log
 import com.google.gson.Gson
 
-class InvalidCredentialsException(): Exception("Invalid credentials")
+class InvalidCredentialsException: Exception("Invalid credentials")
 
 class APIClient(context: Context) {
     private val packageInfo = PackageInfo(context)

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/DNUpdateWorker.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/DNUpdateWorker.kt
@@ -6,7 +6,6 @@ import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import java.io.Closeable
-import java.io.IOException
 import java.nio.channels.FileChannel
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
@@ -35,10 +34,10 @@ class DNUpdateWorker(ctx: Context, params: WorkerParameters) : Worker(ctx, param
             }
         }
 
-        return if (failed) Result.failure() else Result.success();
+        return if (failed) Result.failure() else Result.success()
     }
 
-    fun updateSite(site: Site) {
+    private fun updateSite(site: Site) {
         try {
             DNUpdateLock(site).use {
                 if (updater.updateSite(site)) {
@@ -60,7 +59,7 @@ class DNUpdateWorker(ctx: Context, params: WorkerParameters) : Worker(ctx, param
     }
 }
 
-class DNUpdateLock(private val site: Site): Closeable {
+class DNUpdateLock(site: Site): Closeable {
     private val fileChannel = FileChannel.open(
             Paths.get(site.path+"/update.lock"),
             StandardOpenOption.CREATE,

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/EncFile.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/EncFile.kt
@@ -5,7 +5,7 @@ import androidx.security.crypto.EncryptedFile
 import androidx.security.crypto.MasterKeys
 import java.io.*
 
-class EncFile(var context: Context) {
+class EncFile(private val context: Context) {
     private val scheme = EncryptedFile.FileEncryptionScheme.AES256_GCM_HKDF_4KB
     private val master: String = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
 

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MyApplication.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MyApplication.kt
@@ -1,6 +1,6 @@
 package net.defined.mobile_nebula
 
-import io.flutter.view.FlutterMain
+import io.flutter.embedding.engine.loader.FlutterLoader
 import android.app.Application
 import androidx.work.Configuration
 import androidx.work.WorkManager
@@ -14,6 +14,6 @@ class MyApplication : Application() {
         val myConfig = Configuration.Builder().build()
         WorkManager.initialize(this, myConfig)
 
-        FlutterMain.startInitialization(applicationContext)
+        FlutterLoader().startInitialization(applicationContext)
     }
 }

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/PackageInfo.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/PackageInfo.kt
@@ -2,17 +2,27 @@ package net.defined.mobile_nebula
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
 import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import android.os.Build
 
-class PackageInfo(val context: Context) {
-    private val pInfo: PackageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0)
-    private val appInfo: ApplicationInfo = context.getApplicationInfo()
+class PackageInfo(private val context: Context) {
+    private val pInfo: PackageInfo =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            context.packageManager.getPackageInfo(context.packageName, PackageManager.PackageInfoFlags.of(0))
+        else
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(context.packageName, 0)
+
+    private val appInfo: ApplicationInfo = context.applicationInfo
 
     fun getVersion(): String {
         val version: String = pInfo.versionName
-        val build: Int = pInfo.versionCode
+        val build: Long = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+            pInfo.longVersionCode
+        else
+            @Suppress("DEPRECATION")
+            pInfo.versionCode.toLong()
         return "%s-%d".format(version, build)
     }
 
@@ -22,6 +32,6 @@ class PackageInfo(val context: Context) {
     }
 
     fun getSystemVersion(): String {
-        return Build.VERSION.RELEASE;
+        return Build.VERSION.RELEASE
     }
 }

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -3,12 +3,10 @@ package net.defined.mobile_nebula
 import android.content.Context
 import android.util.Log
 import com.google.gson.Gson
-import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
 import java.io.File
-import java.io.FileNotFoundException
 import kotlin.collections.HashMap
 
 data class SiteContainer(

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.defined.mobile_nebula">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         workVersion = "2.7.1"
-        kotlinVersion = '1.6.10'
+        kotlinVersion = '1.7.20'
     }
 
     repositories {
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }


### PR DESCRIPTION
- Set minSdkVersion to 26 which addresses two problems:
  1. File locking relies on java.nio.file APIs which do not exist until API level >= 26.
  2. Android 6 and Android 7 (API level 23 and 24) do not support the Let's Encrypt TLS certificate served by the DN API.
- Upgraded Kotlin, Gradle, Gson, and targetSdkVersion.
- Fixed a couple spots where code is deprecated.
- Fixed a reference to the wrong variable (vpnIp -> addr).
- Removed some unnecessary imports and semicolons.
- Kotlin style stuff (var vs. val, avoid getters, etc.)

