### PR TITLE
Request VPN permissions on site start

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,8 @@
             <intent-filter>
                 <action android:name="android.net.VpnService"/>
             </intent-filter>
+            <meta-data android:name="android.net.VpnService.SUPPORTS_ALWAYS_ON"
+                android:value="false"/>
         </service>
         <activity
             android:name=".MainActivity"
@@ -48,7 +50,6 @@
                 <data android:scheme="https"/>
             </intent-filter>
         </activity>
-        <receiver android:name=".ShareReceiver" android:exported="false"/>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -284,43 +284,6 @@ class _MainScreenState extends State<MainScreen> {
   }
 
   _loadSites() async {
-    if (Platform.isAndroid) {
-      try {
-        await platform.invokeMethod("android.requestPermissions");
-      } on PlatformException catch (err) {
-        if (err.code == "PERMISSIONS") {
-          setState(() {
-            error = [
-              Text("Permissions Required", style: TextStyle(fontWeight: FontWeight.bold)),
-              Text(
-                  "VPN permissions are required for nebula to run, click the button below request and accept the appropriate permissions.",
-                  textAlign: TextAlign.center),
-              ElevatedButton(
-                  onPressed: () {
-                    error = null;
-                    _loadSites();
-                  },
-                  child: Text("Request Permissions")),
-            ];
-          });
-        } else {
-          setState(() {
-            error = [
-              Text("Unknown Error", style: TextStyle(fontWeight: FontWeight.bold)),
-              Text(err.message ?? 'An unknown error occurred', textAlign: TextAlign.center)
-            ];
-          });
-        }
-      } catch (err) {
-        setState(() {
-          error = [
-            Text("Unknown Error", style: TextStyle(fontWeight: FontWeight.bold)),
-            Text(err.toString(), textAlign: TextAlign.center)
-          ];
-        });
-      }
-    }
-
     //TODO: This can throw, we need to show an error dialog
     Map<String, dynamic> rawSites = jsonDecode(await platform.invokeMethod('listSites'));
     bool hasErrors = false;

--- a/nebula/go.mod
+++ b/nebula/go.mod
@@ -34,8 +34,10 @@ require (
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 // indirect
 	github.com/vishvananda/netlink v1.1.0 // indirect
 	github.com/vishvananda/netns v0.0.1 // indirect
+	golang.org/x/mobile v0.0.0-20221110043201-43a038452099 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect
 	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/tools v0.3.0 // indirect

--- a/nebula/go.sum
+++ b/nebula/go.sum
@@ -275,6 +275,8 @@ golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
+golang.org/x/mobile v0.0.0-20221110043201-43a038452099 h1:aIu0lKmfdgtn2uTj7JI2oN4TUrQvgB+wzTPO23bCKt8=
+golang.org/x/mobile v0.0.0-20221110043201-43a038452099/go.mod h1:aAjjkJNdrh3PMckS4B10TGS2nag27cbKR1y2BpUxsiY=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
@@ -340,6 +342,7 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
Previously VPN permissions were requested when the UI was loaded. If the
user denied the permissions it would have to be force stopped and
reopened to get another permission request grant.

Additionally, when requesting VPN permissions Android will kill any
other running VPN service. This avoids that behavior unless a site is
explicitly started.

Also disables the app from showing up in the "Always On" settings.
