### PR TITLE
Don't require android.hardware.camera feature

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera" android:required="false"
+        tools:replace="required" />
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
flutter_barcode_scanner pulls in this feature but we only need it to be optional. This should help expand support on Chromebook devices.