### PR TITLE
Make user agent consistent on iOS and Android

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/APIClient.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/APIClient.kt
@@ -8,8 +8,7 @@ class InvalidCredentialsException: Exception("Invalid credentials")
 class APIClient(context: Context) {
     private val packageInfo = PackageInfo(context)
     private val client = mobileNebula.MobileNebula.newAPIClient(
-        "%s/%s (Android %s)".format(
-                packageInfo.getName(),
+        "MobileNebula/%s (Android %s)".format(
                 packageInfo.getVersion(),
                 packageInfo.getSystemVersion(),
         ))

--- a/ios/Runner/APIClient.swift
+++ b/ios/Runner/APIClient.swift
@@ -10,7 +10,7 @@ class APIClient {
     
     init() {
         let packageInfo = PackageInfo()
-        apiClient = MobileNebulaNewAPIClient("\(packageInfo.getName())/\(packageInfo.getVersion()) (iOS \(packageInfo.getSystemVersion()))")!
+        apiClient = MobileNebulaNewAPIClient("MobileNebula/\(packageInfo.getVersion()) (iOS \(packageInfo.getSystemVersion()))")!
     }
     
     func enroll(code: String) throws -> IncomingSite {


### PR DESCRIPTION
Instead of Nebula/, Nebula-DEBUG/, and NebulaNetworkExtension/, ensure that the user agent is always MobileNebula/.