### PR TITLE
Add a manual enrollment flow to support chromeos

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -109,21 +109,18 @@ class _AppState extends State<App> {
           ),
           onGenerateRoute: (settings) {
             if (settings.name == '/') {
-              return platformPageRoute(context: context, builder: (context) => MainScreen(this.dnEnrolled.stream));
+              return platformPageRoute(context: context, builder: (context) => MainScreen(this.dnEnrolled));
             }
 
             final uri = Uri.parse(settings.name!);
             if (uri.path == EnrollmentScreen.routeName) {
-              String? code;
-              if (uri.hasFragment) {
-                final qp = Uri.splitQueryString(uri.fragment);
-                code = qp["code"];
-              }
-
               // TODO: maybe implement this as a dialog instead of a page, you can stack multiple enrollment screens which is annoying in dev
               return platformPageRoute(
                   context: context,
-                  builder: (context) => EnrollmentScreen(code: code, stream: this.dnEnrolled),
+                  builder: (context) => EnrollmentScreen(
+                    code: EnrollmentScreen.parseCode(settings.name!),
+                    stream: this.dnEnrolled
+                  ),
               );
             }
 

--- a/lib/screens/AboutScreen.dart
+++ b/lib/screens/AboutScreen.dart
@@ -73,7 +73,7 @@ class _AboutScreenState extends State<AboutScreen> {
         Padding(
             padding: EdgeInsets.only(top: 20),
             child: Text(
-              'Copyright © 2020 Defined Networking, Inc',
+              'Copyright © 2022 Defined Networking, Inc',
               textAlign: TextAlign.center,
             )),
       ]),

--- a/lib/screens/EnrollmentScreen.dart
+++ b/lib/screens/EnrollmentScreen.dart
@@ -156,10 +156,7 @@ class _EnrollmentScreenState extends State<EnrollmentScreen> {
 
     final dnIcon = Theme.of(context).brightness == Brightness.dark ? 'images/dn-logo-dark.svg' : 'images/dn-logo-light.svg';
     return SimplePage(
-      title: Row(children: [
-        Text('Enroll with', style: TextStyle(fontWeight: FontWeight.bold)),
-        Padding(padding: EdgeInsets.only(left: 5), child: SvgPicture.asset(dnIcon, width: 12))
-      ]),
+      title: Text('Enroll with DN', style: TextStyle(fontWeight: FontWeight.bold)),
       child: Padding(child: child, padding: EdgeInsets.symmetric(horizontal: 10)),
       alignment: alignment
     );

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -63,7 +63,7 @@ MAIH7gzreMGgrH/yR6rZpIHR3DxJ3E0aHtEI
 class MainScreen extends StatefulWidget {
   const MainScreen(this.dnEnrollStream, {Key? key}) : super(key: key);
 
-  final Stream dnEnrollStream;
+  final StreamController dnEnrollStream;
 
   @override
   _MainScreenState createState() => _MainScreenState();
@@ -82,7 +82,7 @@ class _MainScreenState extends State<MainScreen> {
   void initState() {
     _loadSites();
 
-    widget.dnEnrollStream.listen((_) {
+    widget.dnEnrollStream.stream.listen((_) {
       _loadSites();
     });
 
@@ -146,7 +146,7 @@ class _MainScreenState extends State<MainScreen> {
         PlatformIconButton(
           padding: EdgeInsets.zero,
           icon: Icon(Icons.menu, size: 28.0),
-          onPressed: () => Utils.openPage(context, (_) => SettingsScreen()),
+          onPressed: () => Utils.openPage(context, (_) => SettingsScreen(widget.dnEnrollStream)),
         ),
       ],
       bottomBar: debugSite,

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -89,10 +89,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     final dnIcon = Theme.of(context).brightness == Brightness.dark ? 'images/dn-logo-dark.svg' : 'images/dn-logo-light.svg';
     items.add(ConfigSection(children: [
       ConfigPageItem(
-        label: Row(children: [
-          Text('Enroll with'),
-          Padding(padding: EdgeInsets.only(left: 5), child: SvgPicture.asset(dnIcon, width: 12))
-        ]),
+        label: Text('Enroll with DN'),
         labelWidth: 200,
         onPressed: () => Utils.openPage(context, (context) => EnrollmentScreen(stream: widget.stream, allowCodeEntry: true))
       )

--- a/lib/screens/SettingsScreen.dart
+++ b/lib/screens/SettingsScreen.dart
@@ -1,18 +1,24 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:mobile_nebula/components/SimplePage.dart';
 import 'package:mobile_nebula/components/config/ConfigItem.dart';
 import 'package:mobile_nebula/components/config/ConfigPageItem.dart';
 import 'package:mobile_nebula/components/config/ConfigSection.dart';
+import 'package:mobile_nebula/screens/EnrollmentScreen.dart';
 import 'package:mobile_nebula/services/settings.dart';
 import 'package:mobile_nebula/services/utils.dart';
 
 import 'AboutScreen.dart';
 
 class SettingsScreen extends StatefulWidget {
+  final StreamController stream;
+
+  const SettingsScreen(this.stream, {super.key});
+
   @override
-  _SettingsScreenState createState() {
-    return _SettingsScreenState();
-  }
+  _SettingsScreenState createState() => _SettingsScreenState();
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
@@ -79,6 +85,19 @@ class _SettingsScreenState extends State<SettingsScreen> {
             },
           )),
     ));
+
+    final dnIcon = Theme.of(context).brightness == Brightness.dark ? 'images/dn-logo-dark.svg' : 'images/dn-logo-light.svg';
+    items.add(ConfigSection(children: [
+      ConfigPageItem(
+        label: Row(children: [
+          Text('Enroll with'),
+          Padding(padding: EdgeInsets.only(left: 5), child: SvgPicture.asset(dnIcon, width: 12))
+        ]),
+        labelWidth: 200,
+        onPressed: () => Utils.openPage(context, (context) => EnrollmentScreen(stream: widget.stream, allowCodeEntry: true))
+      )
+    ]));
+
     items.add(ConfigSection(children: [
       ConfigPageItem(
         label: Text('About'),


### PR DESCRIPTION
This currently places a manual enrollment flow under the hamburger/settings menu. Some minor tweaks have been made to support both a direct code input as well as an enroll url.

<img width="441" alt="Screen Shot 2022-11-21 at 10 30 19 PM" src="https://user-images.githubusercontent.com/957319/203221823-6fc678a8-2065-49be-8cf9-73b1ec9eaaab.png">
<img width="441" alt="Screen Shot 2022-11-21 at 10 30 33 PM" src="https://user-images.githubusercontent.com/957319/203221858-a88804b0-3fe1-4378-b284-89c2b669866f.png">

This also passes the full broadcast stream around so that we can properly trigger a refresh on manual enrollment. We should ensure deep link enrollment isn't affected as it will likely double refresh the main site list now.

...and updated the copyright year since its nearly 2023
