### PR TITLE
Hide QR code scanner on devices without cameras

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.content.ServiceConnection
+import android.content.pm.PackageManager
 import android.net.VpnService
 import android.os.*
 import android.util.Log
@@ -62,6 +63,7 @@ class MainActivity: FlutterActivity() {
         ui!!.setMethodCallHandler { call, result ->
             when(call.method) {
                 "android.registerActiveSite" -> registerActiveSite(result)
+                "android.deviceHasCamera" -> deviceHasCamera(result)
 
                 "nebula.parseCerts" -> nebulaParseCerts(call, result)
                 "nebula.generateKeyPair" -> nebulaGenerateKeyPair(result)
@@ -118,6 +120,10 @@ class MainActivity: FlutterActivity() {
         val intent = Intent(this, NebulaVpnService::class.java)
         bindService(intent, connection, 0)
         result.success(null)
+    }
+
+    private fun deviceHasCamera(result: MethodChannel.Result) {
+        result.success(context.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY))
     }
 
     private fun nebulaParseCerts(call: MethodCall, result: MethodChannel.Result) {

--- a/lib/screens/HostInfoScreen.dart
+++ b/lib/screens/HostInfoScreen.dart
@@ -21,6 +21,7 @@ class HostInfoScreen extends StatefulWidget {
     required this.pending,
     this.onChanged,
     required this.site,
+    required this.supportsQRScanning,
   }) : super(key: key);
 
   final bool isLighthouse;
@@ -28,6 +29,8 @@ class HostInfoScreen extends StatefulWidget {
   final HostInfo hostInfo;
   final Function? onChanged;
   final Site site;
+
+  final bool supportsQRScanning;
 
   @override
   _HostInfoScreenState createState() => _HostInfoScreenState();
@@ -72,7 +75,10 @@ class _HostInfoScreenState extends State<HostInfoScreen> {
               labelWidth: 150,
               content: Text(hostInfo.cert!.details.name),
               onPressed: () => Utils.openPage(
-                  context, (context) => CertificateDetailsScreen(certInfo: CertificateInfo(cert: hostInfo.cert!))))
+                  context, (context) => CertificateDetailsScreen(
+                    certInfo: CertificateInfo(cert: hostInfo.cert!),
+                    supportsQRScanning: widget.supportsQRScanning,
+              )))
           : Container(),
     ]);
   }

--- a/lib/screens/SiteDetailScreen.dart
+++ b/lib/screens/SiteDetailScreen.dart
@@ -21,10 +21,16 @@ import 'package:pull_to_refresh/pull_to_refresh.dart';
 //TODO: ios is now the problem with connecting screwing our ability to query the hostmap (its a race)
 
 class SiteDetailScreen extends StatefulWidget {
-  const SiteDetailScreen({Key? key, required this.site, this.onChanged}) : super(key: key);
+  const SiteDetailScreen({
+    Key? key,
+    required this.site,
+    this.onChanged,
+    required this.supportsQRScanning,
+  }) : super(key: key);
 
   final Site site;
   final Function? onChanged;
+  final bool supportsQRScanning;
 
   @override
   _SiteDetailScreenState createState() => _SiteDetailScreenState();
@@ -193,7 +199,9 @@ class _SiteDetailScreenState extends State<SiteDetailScreen> {
                         setState(() {
                           activeHosts = hosts;
                         });
-                      }));
+                      },
+                      supportsQRScanning: widget.supportsQRScanning,
+                  ));
             },
             label: Text("Active"),
             content: Container(alignment: Alignment.centerRight, child: active)),
@@ -211,7 +219,9 @@ class _SiteDetailScreenState extends State<SiteDetailScreen> {
                         setState(() {
                           pendingHosts = hosts;
                         });
-                      }));
+                      },
+                      supportsQRScanning: widget.supportsQRScanning,
+                  ));
             },
             label: Text("Pending"),
             content: Container(alignment: Alignment.centerRight, child: pending))
@@ -231,7 +241,9 @@ class _SiteDetailScreenState extends State<SiteDetailScreen> {
                 onSave: (site) async {
                   changed = true;
                   setState(() {});
-                });
+                },
+              supportsQRScanning: widget.supportsQRScanning,
+            );
           });
         },
       ),

--- a/lib/screens/SiteTunnelsScreen.dart
+++ b/lib/screens/SiteTunnelsScreen.dart
@@ -10,14 +10,22 @@ import 'package:mobile_nebula/services/utils.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 
 class SiteTunnelsScreen extends StatefulWidget {
-  const SiteTunnelsScreen(
-      {Key? key, required this.site, required this.tunnels, required this.pending, required this.onChanged})
+  const SiteTunnelsScreen({
+    Key? key,
+    required this.site,
+    required this.tunnels,
+    required this.pending,
+    required this.onChanged,
+    required this.supportsQRScanning,
+  })
       : super(key: key);
 
   final Site site;
   final List<HostInfo> tunnels;
   final bool pending;
   final Function(List<HostInfo>)? onChanged;
+
+  final bool supportsQRScanning;
 
   @override
   _SiteTunnelsScreenState createState() => _SiteTunnelsScreenState();
@@ -67,7 +75,10 @@ class _SiteTunnelsScreenState extends State<SiteTunnelsScreen> {
                 site: widget.site,
                 onChanged: () {
                   _listHostmap();
-                })),
+                },
+                supportsQRScanning: widget.supportsQRScanning,
+            ),
+        ),
         label: Row(children: <Widget>[Padding(child: icon, padding: EdgeInsets.only(right: 10)), Text(hostInfo.vpnIp)]),
         labelWidth: ipWidth,
         content: Container(alignment: Alignment.centerRight, child: Text(hostInfo.cert?.details.name ?? "")),

--- a/lib/screens/siteConfig/AddCertificateScreen.dart
+++ b/lib/screens/siteConfig/AddCertificateScreen.dart
@@ -30,6 +30,7 @@ class AddCertificateScreen extends StatefulWidget {
     this.onReplace,
     required this.pubKey,
     required this.privKey,
+    required this.supportsQRScanning,
   }) : super(key: key);
 
   // onSave will pop a new CertificateDetailsScreen.
@@ -41,6 +42,8 @@ class AddCertificateScreen extends StatefulWidget {
 
   final String pubKey;
   final String privKey;
+
+  final bool supportsQRScanning;
 
   @override
   _AddCertificateScreenState createState() => _AddCertificateScreenState();
@@ -100,6 +103,16 @@ class _AddCertificateScreenState extends State<AddCertificateScreen> {
   }
 
   List<Widget> _buildLoadCert() {
+    Map<String, Widget> children = {
+      'paste': Text('Copy/Paste'),
+      'file': Text('File'),
+    };
+
+    // not all devices have a camera for QR codes
+    if (widget.supportsQRScanning) {
+      children['qr'] = Text('QR Code');
+    }
+
     List<Widget> items = [
       Padding(
           padding: EdgeInsets.fromLTRB(10, 25, 10, 0),
@@ -112,11 +125,7 @@ class _AddCertificateScreenState extends State<AddCertificateScreen> {
                 });
               }
             },
-            children: {
-              'paste': Text('Copy/Paste'),
-              'file': Text('File'),
-              'qr': Text('QR Code'),
-            },
+            children: children,
           ))
     ];
 
@@ -124,7 +133,7 @@ class _AddCertificateScreenState extends State<AddCertificateScreen> {
       items.addAll(_addPaste());
     } else if (inputType == 'file') {
       items.addAll(_addFile());
-    } else {
+    } else if (inputType == 'qr') {
       items.addAll(_addQr());
     }
 
@@ -257,7 +266,9 @@ class _AddCertificateScreenState extends State<AddCertificateScreen> {
                 onSave: () {
                   Navigator.pop(context);
                   widget.onSave!(CertificateResult(certInfo: tryCertInfo, key: keyController.text));
-                });
+                },
+                supportsQRScanning: widget.supportsQRScanning,
+            );
           });
         }
       }

--- a/lib/screens/siteConfig/CAListScreen.dart
+++ b/lib/screens/siteConfig/CAListScreen.dart
@@ -21,10 +21,13 @@ class CAListScreen extends StatefulWidget {
     Key? key,
     required this.cas,
     this.onSave,
+    required this.supportsQRScanning,
   }) : super(key: key);
 
   final List<CertificateInfo> cas;
   final ValueChanged<List<CertificateInfo>>? onSave;
+
+  final bool supportsQRScanning;
 
   @override
   _CAListScreenState createState() => _CAListScreenState();
@@ -88,7 +91,9 @@ class _CAListScreenState extends State<CAListScreen> {
                     changed = true;
                     cas.remove(key);
                   });
-                });
+                },
+                supportsQRScanning: widget.supportsQRScanning,
+            );
           });
         },
       ));
@@ -129,6 +134,16 @@ class _CAListScreenState extends State<CAListScreen> {
   }
 
   List<Widget> _addCA() {
+    Map<String, Widget> children = {
+      'paste': Text('Copy/Paste'),
+      'file': Text('File'),
+    };
+
+    // not all devices have a camera for QR codes
+    if (widget.supportsQRScanning) {
+      children['qr'] = Text('QR Code');
+    }
+
     List<Widget> items = [
       Padding(
           padding: EdgeInsets.fromLTRB(10, 25, 10, 0),
@@ -141,11 +156,7 @@ class _CAListScreenState extends State<CAListScreen> {
                 });
               }
             },
-            children: {
-              'paste': Text('Copy/Paste'),
-              'file': Text('File'),
-              'qr': Text('QR Code'),
-            },
+            children: children,
           ))
     ];
 

--- a/lib/screens/siteConfig/CertificateDetailsScreen.dart
+++ b/lib/screens/siteConfig/CertificateDetailsScreen.dart
@@ -18,6 +18,7 @@ class CertificateDetailsScreen extends StatefulWidget {
     this.onReplace,
     this.pubKey,
     this.privKey,
+    required this.supportsQRScanning,
   }) : super(key: key);
 
   final CertificateInfo certInfo;
@@ -34,6 +35,8 @@ class CertificateDetailsScreen extends StatefulWidget {
   // pubKey and privKey should be set if onReplace is not null.
   final String? pubKey;
   final String? privKey;
+
+  final bool supportsQRScanning;
 
   @override
   _CertificateDetailsScreenState createState() => _CertificateDetailsScreenState();
@@ -178,7 +181,9 @@ class _CertificateDetailsScreenState extends State<CertificateDetailsScreen> {
                               duration: const Duration(milliseconds: 10), curve: Curves.linearToEaseOut);
                         },
                         pubKey: widget.pubKey!,
-                        privKey: widget.privKey!);
+                        privKey: widget.privKey!,
+                        supportsQRScanning: widget.supportsQRScanning,
+                    );
                   });
                 })));
   }

--- a/lib/screens/siteConfig/SiteConfigScreen.dart
+++ b/lib/screens/siteConfig/SiteConfigScreen.dart
@@ -27,12 +27,15 @@ class SiteConfigScreen extends StatefulWidget {
     Key? key,
     this.site,
     required this.onSave,
+    required this.supportsQRScanning,
   }) : super(key: key);
 
   final Site? site;
 
   // This is called after the target OS has saved the configuration
   final ValueChanged<Site> onSave;
+
+  final bool supportsQRScanning;
 
   @override
   _SiteConfigScreenState createState() => _SiteConfigScreenState();
@@ -186,7 +189,9 @@ class _SiteConfigScreenState extends State<SiteConfigScreen> {
                         site.certInfo = result.certInfo;
                         site.key = result.key;
                       });
-                    });
+                    },
+                    supportsQRScanning: widget.supportsQRScanning,
+                );
               }
 
               return AddCertificateScreen(
@@ -198,7 +203,9 @@ class _SiteConfigScreenState extends State<SiteConfigScreen> {
                       site.certInfo = result.certInfo;
                       site.key = result.key;
                     });
-                  });
+                  },
+                supportsQRScanning: widget.supportsQRScanning,
+              );
             });
           },
         ),
@@ -222,7 +229,9 @@ class _SiteConfigScreenState extends State<SiteConfigScreen> {
                         changed = true;
                         site.ca = ca;
                       });
-                    });
+                    },
+                    supportsQRScanning: widget.supportsQRScanning,
+                );
               });
             })
       ],


### PR DESCRIPTION
On Android, some devices lack the camera hardware feature (e.g. many Chromebooks, even if they technically do have a webcam.) If they do, attempting to scan a QR code will crash the app.

This change hides the "QR Code" option from devices without the camera feature.