### PR TITLE
Hide CA expiration errors on managed sites

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -52,7 +52,7 @@ class Sites(private var engine: FlutterEngine) {
         val context = MainActivity.getContext()!!
         val site = containers[id]!!.site
 
-        val baseDir = if(site.managed == true) context.noBackupFilesDir else context.filesDir
+        val baseDir = if(site.managed) context.noBackupFilesDir else context.filesDir
         val siteDir = baseDir.resolve("sites").resolve(id)
         siteDir.deleteRecursively()
         refreshSites()
@@ -275,7 +275,7 @@ class Site(context: Context, siteDir: File) {
                 }
             }
 
-            if (hasErrors) {
+            if (hasErrors && !managed) {
                 errors.add("There are issues with 1 or more ca certificates")
             }
 

--- a/lib/screens/siteConfig/SiteConfigScreen.dart
+++ b/lib/screens/siteConfig/SiteConfigScreen.dart
@@ -154,13 +154,16 @@ class _SiteConfigScreenState extends State<SiteConfigScreen> {
 
   Widget _keys() {
     final certError = site.certInfo == null || site.certInfo!.validity == null || !site.certInfo!.validity!.valid;
-    var caError = site.ca.length == 0;
-    if (!caError) {
-      site.ca.forEach((ca) {
-        if (ca.validity == null || !ca.validity!.valid) {
-          caError = true;
-        }
-      });
+    var caError = false;
+    if (!site.managed) {
+      var caError = site.ca.length == 0;
+      if (!caError) {
+        site.ca.forEach((ca) {
+          if (ca.validity == null || !ca.validity!.valid) {
+            caError = true;
+          }
+        });
+      }
     }
 
     return ConfigSection(


### PR DESCRIPTION
Fixes #123.

This ended up being a bit tricky to test since I can't get the prod API to send down an expired cert. Instead I used the "Bad Site" button to create a site with an expired CA and inverted the `managed` logic. This isn't a perfect test because 

This removes the error which shows up on the main screen, as well as the one inside the Site Configuration page. It does not remove the indicator when you drill down into the CA itself.

<img width="335" alt="Screenshot 2023-05-17 at 11 32 30 AM" src="https://github.com/DefinedNet/mobile_nebula/assets/440033/14fb47fa-6456-469e-8333-2821a382a462">
<img width="490" alt="Screenshot 2023-05-17 at 11 32 34 AM" src="https://github.com/DefinedNet/mobile_nebula/assets/440033/29a26088-3dbf-4e9e-8e61-5adc3ce03d1c">

The nebula configTest should pass as long as there is at least one valid CA in the bundle and the host certificate is unexpired.