### PR TITLE
Rework the ios startup flow slightly to avoid crashing on ios 16.5

### DIFF
--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -97,7 +97,7 @@ struct CertificateValidity: Codable {
 let statusMap: Dictionary<NEVPNStatus, Bool> = [
     NEVPNStatus.invalid: false,
     NEVPNStatus.disconnected: false,
-    NEVPNStatus.connecting: true,
+    NEVPNStatus.connecting: false,
     NEVPNStatus.connected: true,
     NEVPNStatus.reasserting: true,
     NEVPNStatus.disconnecting: true,

--- a/ios/Runner/Sites.swift
+++ b/ios/Runner/Sites.swift
@@ -134,22 +134,22 @@ class SiteUpdater: NSObject, FlutterStreamHandler {
         }
         
         self.notification = NotificationCenter.default.addObserver(forName: NSNotification.Name.NEVPNStatusDidChange, object: site.manager!.connection , queue: nil) { n in
-            let connected = self.site.connected
+            let oldConnected = self.site.connected
             self.site.status = statusString[self.site.manager!.connection.status]
             self.site.connected = statusMap[self.site.manager!.connection.status]
-
+            
             // Check to see if we just moved to connected and if we have a start function to call when that happens
-            if self.site.connected! && connected != self.site.connected && self.startFunc != nil {
+            if self.site.connected! && oldConnected != self.site.connected && self.startFunc != nil {
                 self.startFunc!()
                 self.startFunc = nil
             }
-
+            
             self.update(connected: self.site.connected!)
         }
 #endif
         return nil
     }
-
+    
     /// onCancel is called when the flutter listener stops listening
     func onCancel(withArguments arguments: Any?) -> FlutterError? {
         if (self.notification != nil) {


### PR DESCRIPTION
iOS 16.5 changed the IPC behavior with the vpn process which caused the process to crash if it received an `appMessage` before it was "ready".

This change no longer caches the system `completionHandler` when being asked to start by the UI, instead calling it immediately, which appears to get the vpn process in the "ready" state. 

This also changes when the UI side determines its safe to send an `appMessage`, this will delay the ui toggle flip from off -> on by a little bit.

There is an opportunity to make the experience feel snappy like pre 16.5 days but it will require a larger lift.

Closes #131 