### PR TITLE
Don't use Nebula tunnel for app traffic on Android

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -118,6 +118,9 @@ class NebulaVpnService : VpnService() {
 
         // Disallow some common, known-problematic apps
         // TODO Make this user configurable
+        // Ensure that a misconfigured unsafe_route doesn't block access to the DN API
+        disallowApp(builder, "net.defined.mobile_nebula")
+        disallowApp(builder, "net.defined.mobile_nebula.debug")
         // Android Auto Wireless (https://github.com/DefinedNet/mobile_nebula/issues/102)
         disallowApp(builder, "com.google.android.projection.gearhead")
         // Chromecast (https://github.com/DefinedNet/mobile_nebula/issues/102)


### PR DESCRIPTION
Avoids an issue where a route misconfigured for `0.0.0.0/0` could break connection to the DN API. In the event that packets cannot flow, it would not be possible to update the broken config while the site is active.