### PR TITLE
Support android API 34

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -98,7 +98,7 @@ class MainActivity: FlutterActivity() {
 
         apiClient = APIClient(context)
 
-        registerReceiver(refreshReceiver, IntentFilter(ACTION_REFRESH_SITES))
+        registerReceiver(refreshReceiver, IntentFilter(ACTION_REFRESH_SITES), RECEIVER_NOT_EXPORTED)
 
         enqueueDNUpdater()
     }

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -213,7 +213,7 @@ class NebulaVpnService : VpnService() {
     }
 
     private fun registerReloadReceiver() {
-        registerReceiver(reloadReceiver, IntentFilter(ACTION_RELOAD))
+        registerReceiver(reloadReceiver, IntentFilter(ACTION_RELOAD), RECEIVER_NOT_EXPORTED)
     }
 
     private fun unregisterReloadReceiver() {


### PR DESCRIPTION
These parameters are now required in android api level 34.  See https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported.

I tested by enabling a "good site" in the emulator, but it would be great if someone could test that vpn functionality still does work as expected on a real phone. 