### PR TITLE
Update java to 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
 
       - name: Install flutter
         uses: subosito/flutter-action@v2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,12 +29,12 @@ android {
     compileSdkVersion 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     sourceSets {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,15 +28,6 @@ android {
 
     compileSdkVersion 34
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -69,6 +60,12 @@ android {
             resValue 'string', 'app_name', '"Nebula-DEBUG"'
             applicationIdSuffix '.debug'
         }
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -17,6 +17,7 @@ pluginManagement {
 }
 
 plugins {
+    id "org.gradle.toolchains.foojay-resolver-convention" version "0.8.0"
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version '8.6.1' apply false
     id "org.jetbrains.kotlin.android" version "2.0.20" apply false


### PR DESCRIPTION
This updates the version of java used during release builds to 17, the minimum required by our version of AGP. https://developer.android.com/build/releases/gradle-plugin#compatibility

It also uses a java toolchain and resolver plugin to automatically download and use the desired version of java, which will hopefully simplify things for others to get spun up on mobile app dev.  Reference https://stefma.medium.com/sourcecompatibility-targetcompatibility-and-jvm-toolchains-in-gradle-explained-d2c17c8cff7c for some explanation of toolchains and compatibility targets, and https://docs.gradle.org/current/userguide/toolchains.html#sec:provisioning for notes about automatic provisioning via toolchain.