### PR TITLE
Specify correct ndk version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,6 @@ jobs:
         with:
           flutter-version: '3.24.1'
 
-      - uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r21b
-          # r21b is 21.1.6352462, if it is not published here https://developer.android.com/ndk/downloads
-          # or here https://github.com/android/ndk/wiki/Unsupported-Downloads then you must download them and look at
-          # source.properties to determine the version
-
       - name: Check out code
         uses: actions/checkout@v3
 
@@ -112,7 +104,6 @@ jobs:
       - name: Build Android
         env:
           TOKEN: ${{ secrets.MACHINE_USER_PAT }}
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
           GOOGLE_PLAY_KEYSTORE_PASSWORD: ${{ secrets.GOOGLE_PLAY_KEYSTORE_PASSWORD }}
         run: |
           flutter build appbundle --build-number="$BUILD_NUMBER" --build-name="$BUILD_NAME"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -28,6 +28,9 @@ android {
 
     compileSdkVersion 34
 
+    // default ndk version for AGP 8.5: https://developer.android.com/build/releases/past-releases/agp-8-5-0-release-notes
+    ndkVersion "26.1.10909125"
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/nebula/Makefile
+++ b/nebula/Makefile
@@ -7,7 +7,7 @@ clean:
 
 mobileNebula.aar: *.go go.sum
 	go get -d golang.org/x/mobile/cmd/gomobile
-	gomobile bind -trimpath -v --target=android
+	gomobile bind -trimpath -v --target=android -androidapi 26
 
 MobileNebula.xcframework: *.go go.sum
 	go get -d golang.org/x/mobile/cmd/gomobile


### PR DESCRIPTION
By specifying the default version for our AGP in our build.gradle, we'll be sure to use it.  Otherwise, whatever is installed will be used, which is less safe.

Ref https://github.com/golang/go/issues/52470