### PR TITLE
Pop confirmation modal only for changed forms

### DIFF
--- a/lib/components/FormPage.dart
+++ b/lib/components/FormPage.dart
@@ -39,7 +39,7 @@ class _FormPageState extends State<FormPage> {
     changed = widget.changed || changed;
 
     return PopScope<Object?>(
-        canPop: false,
+        canPop: !changed,
         onPopInvokedWithResult: (bool didPop, Object? result) async {
           if (didPop) {
             return;


### PR DESCRIPTION
Fixes #174. Also verified using "Good Site" debug tool that modifying forms causes the prompt to appear, and that "Yes/No" options on the prompt work correctly.