### PR TITLE
Move print logs to OSLogger

### DIFF
--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -7,7 +7,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var networkMonitor: NWPathMonitor?
     
     private var site: Site?
-    static let log = Logger(subsystem: "net.defined.mobileNebula", category: "PacketTunnelProvider")
+    private let log = Logger(subsystem: "net.defined.mobileNebula", category: "PacketTunnelProvider")
     private var nebula: MobileNebulaNebula?
     private var dnUpdater = DNUpdater()
     private var didSleep = false
@@ -37,7 +37,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             config = try site!.getConfig()
         } catch {
             //TODO: need a way to notify the app
-            Self.log.error("Failed to render config from vpn object")
+            log.error("Failed to render config from vpn object")
             return completionHandler(error)
         }
 
@@ -89,7 +89,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self.startNetworkMonitor()
 
             if err != nil {
-                Self.log.error("We had an error starting up: \(err, privacy: .public)")
+                self.log.error("We had an error starting up: \(err, privacy: .public)")
                 return completionHandler(err!)
             }
             
@@ -106,7 +106,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             try self.nebula?.reload(String(data: newSite.getConfig(), encoding: .utf8), key: newSite.getKey())
             
         } catch {
-            Self.log.error("Got an error while updating nebula \(error.localizedDescription, privacy: .public)")
+            log.error("Got an error while updating nebula \(error.localizedDescription, privacy: .public)")
         }
     }
     
@@ -162,7 +162,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     
     override func handleAppMessage(_ data: Data, completionHandler: ((Data?) -> Void)? = nil) {
         guard let call = try? JSONDecoder().decode(IPCRequest.self, from: data) else {
-            Self.log.error("Failed to decode IPCRequest from network extension")
+            log.error("Failed to decode IPCRequest from network extension")
             return
         }
         
@@ -190,7 +190,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         
         if nebula == nil {
             // Respond with an empty success message in the event a command comes in before we've truly started
-            Self.log.warning("Received command but do not have a nebula instance")
+            log.warning("Received command but do not have a nebula instance")
             return completionHandler!(try? JSONEncoder().encode(IPCResponse.init(type: .success, message: nil)))
         }
         

--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -7,7 +7,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     private var networkMonitor: NWPathMonitor?
     
     private var site: Site?
-    private var log = Logger(subsystem: "net.defined.mobileNebula", category: "PacketTunnelProvider")
+    static let log = Logger(subsystem: "net.defined.mobileNebula", category: "PacketTunnelProvider")
     private var nebula: MobileNebulaNebula?
     private var dnUpdater = DNUpdater()
     private var didSleep = false
@@ -37,7 +37,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             config = try site!.getConfig()
         } catch {
             //TODO: need a way to notify the app
-            log.error("Failed to render config from vpn object")
+            Self.log.error("Failed to render config from vpn object")
             return completionHandler(error)
         }
 
@@ -89,7 +89,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             self.startNetworkMonitor()
 
             if err != nil {
-                self.log.error("We had an error starting up: \(err, privacy: .public)")
+                Self.log.error("We had an error starting up: \(err, privacy: .public)")
                 return completionHandler(err!)
             }
             
@@ -106,7 +106,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             try self.nebula?.reload(String(data: newSite.getConfig(), encoding: .utf8), key: newSite.getKey())
             
         } catch {
-            self.log.error("Got an error while updating nebula \(error.localizedDescription, privacy: .public)")
+            Self.log.error("Got an error while updating nebula \(error.localizedDescription, privacy: .public)")
         }
     }
     
@@ -162,7 +162,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     
     override func handleAppMessage(_ data: Data, completionHandler: ((Data?) -> Void)? = nil) {
         guard let call = try? JSONDecoder().decode(IPCRequest.self, from: data) else {
-            log.error("Failed to decode IPCRequest from network extension")
+            Self.log.error("Failed to decode IPCRequest from network extension")
             return
         }
         
@@ -190,7 +190,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         
         if nebula == nil {
             // Respond with an empty success message in the event a command comes in before we've truly started
-            log.warning("Received command but do not have a nebula instance")
+            Self.log.warning("Received command but do not have a nebula instance")
             return completionHandler!(try? JSONEncoder().encode(IPCResponse.init(type: .success, message: nil)))
         }
         

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -3,7 +3,7 @@ import MobileNebula
 import SwiftyJSON
 import os.log
 
-var log = Logger(subsystem: "net.defined.mobileNebula", category: "Site")
+let log = Logger(subsystem: "net.defined.mobileNebula", category: "Site")
 
 extension String: Error {}
 

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -1,6 +1,9 @@
 import NetworkExtension
 import MobileNebula
 import SwiftyJSON
+import os.log
+
+var log = Logger(subsystem: "net.defined.mobileNebula", category: "Site")
 
 extension String: Error {}
 
@@ -430,7 +433,7 @@ struct IncomingSite: Codable {
             return
         }
 
-        print("Saving to \(configPath)")
+        log.notice("Saving to \(configPath, privacy: .public)")
         do {
             if (self.key != nil) {
                 let data = self.key!.data(using: .utf8)

--- a/ios/Runner/DNUpdate.swift
+++ b/ios/Runner/DNUpdate.swift
@@ -3,8 +3,8 @@ import os.log
 
 class DNUpdater {
     private let apiClient = APIClient()
-    private let timer = RepeatingTimer(timeInterval: 15 * 60) // 15 * 60 is 15 minutes
-    static let log = Logger(subsystem: "net.defined.mobileNebula", category: "DNUpdater")
+    private let timer = RepeatingTimer(timeInterval: 30) // 15 * 60 is 15 minutes
+    private let log = Logger(subsystem: "net.defined.mobileNebula", category: "DNUpdater")
     
     func updateAll(onUpdate: @escaping (Site) -> ()) {
         _ = SiteList{ (sites, _) -> () in
@@ -57,7 +57,7 @@ class DNUpdater {
             } catch (APIClientError.invalidCredentials) {
                 if (!credentials.invalid) {
                     try site.invalidateDNCredentials()
-                    Self.log.notice("Invalidated credentials in site: \(site.name, privacy: .public)")
+                    log.notice("Invalidated credentials in site: \(site.name, privacy: .public)")
                 }
                 
                 return
@@ -65,7 +65,7 @@ class DNUpdater {
             
             newSite?.save(manager: nil) { error in
                 if (error != nil) {
-                    Self.log.error("failed to save update: \(error!.localizedDescription, privacy: .public)")
+                    self.log.error("failed to save update: \(error!.localizedDescription, privacy: .public)")
                 } else {
                     onUpdate(Site(incoming: newSite!))
                 }
@@ -73,11 +73,11 @@ class DNUpdater {
             
             if (credentials.invalid) {
                 try site.validateDNCredentials()
-                Self.log.notice("Revalidated credentials in site \(site.name, privacy: .public)")
+                log.notice("Revalidated credentials in site \(site.name, privacy: .public)")
             }
             
         } catch {
-            Self.log.error("Error while updating \(site.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
+            log.error("Error while updating \(site.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/ios/Runner/DNUpdate.swift
+++ b/ios/Runner/DNUpdate.swift
@@ -1,8 +1,10 @@
 import Foundation
+import os.log
 
 class DNUpdater {
     private let apiClient = APIClient()
     private let timer = RepeatingTimer(timeInterval: 15 * 60) // 15 * 60 is 15 minutes
+    static let log = Logger(subsystem: "net.defined.mobileNebula", category: "DNUpdater")
     
     func updateAll(onUpdate: @escaping (Site) -> ()) {
         _ = SiteList{ (sites, _) -> () in
@@ -55,7 +57,7 @@ class DNUpdater {
             } catch (APIClientError.invalidCredentials) {
                 if (!credentials.invalid) {
                     try site.invalidateDNCredentials()
-                    print("Invalidated credentials in site \(site.name)")
+                    Self.log.notice("Invalidated credentials in site: \(site.name, privacy: .public)")
                 }
                 
                 return
@@ -63,7 +65,7 @@ class DNUpdater {
             
             newSite?.save(manager: nil) { error in
                 if (error != nil) {
-                    print("failed to save update: \(error!.localizedDescription)")
+                    Self.log.error("failed to save update: \(error!.localizedDescription, privacy: .public)")
                 } else {
                     onUpdate(Site(incoming: newSite!))
                 }
@@ -71,11 +73,11 @@ class DNUpdater {
             
             if (credentials.invalid) {
                 try site.validateDNCredentials()
-                print("Revalidated credentials in site \(site.name)")
+                Self.log.notice("Revalidated credentials in site \(site.name, privacy: .public)")
             }
             
         } catch {
-            print("Error while updating \(site.name): \(error.localizedDescription)")
+            Self.log.error("Error while updating \(site.name, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 }


### PR DESCRIPTION
This aids in debugging in console.app, since `print` statements from the PacketTunnelProvider are not shown in xcode's console.