### PR TITLE
Update to support netip use in Nebula 1.9.4

### DIFF
--- a/lib/models/HostInfo.dart
+++ b/lib/models/HostInfo.dart
@@ -21,7 +21,7 @@ class HostInfo {
 
   factory HostInfo.fromJson(Map<String, dynamic> json) {
     UDPAddress? currentRemote;
-    if (json['currentRemote'] != null) {
+    if (json['currentRemote'] != "") {
       currentRemote = UDPAddress.fromJson(json['currentRemote']);
     }
 
@@ -52,6 +52,11 @@ class UDPAddress {
   String ip;
   int port;
 
+  UDPAddress({
+    required this.ip,
+    required this.port,
+  });
+
   @override
   String toString() {
     // Simple check on if nebula told us about a v4 or v6 ip address
@@ -62,7 +67,17 @@ class UDPAddress {
     return '$ip:$port';
   }
 
-  UDPAddress.fromJson(Map<String, dynamic> json)
-      : ip = json['ip'],
-        port = json['port'];
+  factory UDPAddress.fromJson(String json) {
+    // IPv4 Address
+    if (json.contains('.')) {
+      var ip = json.split(':')[0];
+      var port = int.parse(json.split(':')[1]);
+      return UDPAddress(ip: ip, port: port);
+    }
+
+    // IPv6 Address
+    var ip = json.split(']')[0].substring(1);
+    var port = int.parse(json.split(']')[1].split(':')[1]);
+    return UDPAddress(ip: ip, port: port);
+  }
 }

--- a/nebula/go.mod
+++ b/nebula/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/vishvananda/netlink v1.3.0 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
+	golang.org/x/mobile v0.0.0-20241016134751-7ff83004ec2c // indirect
 	golang.org/x/mod v0.21.0 // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect

--- a/nebula/go.sum
+++ b/nebula/go.sum
@@ -159,6 +159,8 @@ golang.org/x/crypto v0.28.0/go.mod h1:rmgy+3RHxRZMyY0jjAJShp2zgEdOqj2AO7U0pYmeQ7
 golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c h1:7dEasQXItcW1xKJ2+gg5VOiBnqWrJc+rq0DPKyvvdbY=
 golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c/go.mod h1:NQtJDoLvd6faHhE7m4T/1IY708gDefGGjR/iUW8yQQ8=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mobile v0.0.0-20241016134751-7ff83004ec2c h1:zuNS/LWsEpPTLfrmBkis6Xofw3nieAqB4hYLn8+uswk=
+golang.org/x/mobile v0.0.0-20241016134751-7ff83004ec2c/go.mod h1:snk1Mn2ZpdKCt90JPEsDh4sL3ReK520U2t0d7RHBnSU=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=


### PR DESCRIPTION
1. Update the glue code (`nebula/control.go`) to pass `netip.Addr` instead of `iputil.VpnIp` to Nebula.
2. `netip.Addr` marshals as a string instead of a dictionary, so properly unmarshal it in Dart.