### PR TITLE
Add providerBundleIdentifier to avoid permissions errors

### DIFF
--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -488,7 +488,7 @@ struct IncomingSite: Codable {
     private func finishSaveToManager(manager: NETunnelProviderManager, callback: @escaping (Error?) -> ()) {
         // Stuff our details in the protocol
         let proto = manager.protocolConfiguration as? NETunnelProviderProtocol ?? NETunnelProviderProtocol()
-
+        proto.providerBundleIdentifier = "net.defined.mobileNebula.NebulaNetworkExtension";
         proto.providerConfiguration = ["id": self.id]
         proto.serverAddress = "Nebula"
 


### PR DESCRIPTION
This allows the network extension to save to the vpn profile without permissions errors.

To test: start a debug build, start up a managed site, make a change that triggers a `doUpdate` that changes the certificate, wait for the update to happen, and verify that the host cert has been updated.