### PR TITLE
Handle managed nebula updates correctly

### DIFF
--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -32,25 +32,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         try await start()
     }
     
-    private func findManager() async throws -> NETunnelProviderManager {
-        let targetProtoConfig = self.protocolConfiguration as? NETunnelProviderProtocol;
-        let targetID = targetProtoConfig?.providerConfiguration!["id"] as? String;
-        
-        // Load vpn configs from system, and find the manager matching the one being started
-        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-        for manager in managers {
-            let mgrProtoConfig = manager.protocolConfiguration as? NETunnelProviderProtocol;
-            let id = mgrProtoConfig?.providerConfiguration!["id"] as? String;
-            
-            if (id == targetID) {
-                return manager
-            }
-        }
-        
-        // If we didn't find anything, throw an error
-        throw VPNStartError.noManagers
-    }
-    
     private func start() async throws {
         var manager: NETunnelProviderManager?
         var config: Data
@@ -132,6 +113,25 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 //        nebula!.sleep()
 //        completionHandler()
 //    }
+    
+    private func findManager() async throws -> NETunnelProviderManager {
+        let targetProtoConfig = self.protocolConfiguration as? NETunnelProviderProtocol;
+        let targetID = targetProtoConfig?.providerConfiguration!["id"] as? String;
+        
+        // Load vpn configs from system, and find the manager matching the one being started
+        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+        for manager in managers {
+            let mgrProtoConfig = manager.protocolConfiguration as? NETunnelProviderProtocol;
+            let id = mgrProtoConfig?.providerConfiguration!["id"] as? String;
+            
+            if (id == targetID) {
+                return manager
+            }
+        }
+        
+        // If we didn't find anything, throw an error
+        throw VPNStartError.noManagers
+    }
     
     private func startNetworkMonitor() {
         networkMonitor = NWPathMonitor()

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -489,6 +489,8 @@ struct IncomingSite: Codable {
         // Stuff our details in the protocol
         let proto = manager.protocolConfiguration as? NETunnelProviderProtocol ?? NETunnelProviderProtocol()
         proto.providerBundleIdentifier = "net.defined.mobileNebula.NebulaNetworkExtension";
+        // WARN: If we stop setting providerConfiguration["id"] here, we'll need to use something else to match
+        // managers in PacketTunnelProvider.findManager
         proto.providerConfiguration = ["id": self.id]
         proto.serverAddress = "Nebula"
 

--- a/ios/Runner/DNUpdate.swift
+++ b/ios/Runner/DNUpdate.swift
@@ -63,7 +63,7 @@ class DNUpdater {
                 return
             }
             
-            newSite?.save(manager: nil) { error in
+            newSite?.save(manager: site.manager) { error in
                 if (error != nil) {
                     self.log.error("failed to save update: \(error!.localizedDescription, privacy: .public)")
                 } else {

--- a/ios/Runner/DNUpdate.swift
+++ b/ios/Runner/DNUpdate.swift
@@ -66,9 +66,10 @@ class DNUpdater {
             newSite?.save(manager: site.manager) { error in
                 if (error != nil) {
                     self.log.error("failed to save update: \(error!.localizedDescription, privacy: .public)")
-                } else {
-                    onUpdate(Site(incoming: newSite!))
                 }
+                
+                // reload nebula even if we couldn't save the vpn profile
+                onUpdate(Site(incoming: newSite!))
             }
             
             if (credentials.invalid) {

--- a/ios/Runner/DNUpdate.swift
+++ b/ios/Runner/DNUpdate.swift
@@ -3,7 +3,7 @@ import os.log
 
 class DNUpdater {
     private let apiClient = APIClient()
-    private let timer = RepeatingTimer(timeInterval: 30) // 15 * 60 is 15 minutes
+    private let timer = RepeatingTimer(timeInterval: 15 * 60) // 15 * 60 is 15 minutes
     private let log = Logger(subsystem: "net.defined.mobileNebula", category: "DNUpdater")
     
     func updateAll(onUpdate: @escaping (Site) -> ()) {


### PR DESCRIPTION
This fixes a few issues:

1) When updates are made, we will no longer create duplicate VPN profiles, rather we will update existing ones.
2) We will correctly update an existing profile when the site is running and an update is received, rather than attempting to create a new profile, which failed due to permissions errors.  
3) We will always reload nebula, even if we can't successfully save the VPN profile.
4) The default polling interval of 15 minutes is restored (previously set to 30 seconds during testing).

So far in manual testing I've confirmed that I do not lose the tunnel to my lighthouse even after the original 30 minute expiration of a certificate.  This confirms that reloads are occurring correctly.  Additionally, duplicate sites are not created when updates occur while the site is disconnected.