### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/flutterfmt.yml
+++ b/.github/workflows/flutterfmt.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          progress: false
+          show-progress: false
 
       - name: Check formating
         run: dart format -l120 lib/ --set-exit-if-changed --suppress-analytics --output none

--- a/.github/workflows/flutterfmt.yml
+++ b/.github/workflows/flutterfmt.yml
@@ -21,7 +21,9 @@ jobs:
           flutter-version: '3.24.1'
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          progress: false
 
       - name: Check formating
         run: dart format -l120 lib/ --set-exit-if-changed --suppress-analytics --output none

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
-          progress: false
+          show-progress: false
 
       - name: Install goimports
         working-directory: nebula

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -22,7 +22,9 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          progress: false
 
       - name: Install goimports
         working-directory: nebula

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -14,17 +14,16 @@ jobs:
     name: Run gofmt
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-        id: go
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
-        with:
-          show-progress: false
+          cache-dependency-path: nebula/go.sum
 
       - name: Install goimports
         working-directory: nebula

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
       - name: Set up Go 1.22
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22"
         id: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           fi
 
       - name: Collect iOS artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MobileNebula.ipa
           path: ios/MobileNebula.ipa
@@ -122,7 +122,7 @@ jobs:
           fi
 
       - name: Collect Android artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: MobileNebula.aab
           path: build/app/outputs/bundle/release/app-release.aab

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,11 @@ jobs:
           cd android
           fastlane release
 
+      - name: Rename app bundle
+        run: |
+          mv build/app/outputs/bundle/release/app-release.aab \
+            build/app/outputs/bundle/release/MobileNebula.aab
+
       - name: Create GitHub Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -149,16 +154,7 @@ jobs:
           draft: true
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload release Android app
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/app/outputs/bundle/release/app-release.aab
-          asset_name: MobileNebula.aab
-          asset_content_type: text/plain
+          files: build/app/outputs/bundle/release/MobileNebula.aab
 
       - name: Upload release iOS app
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,16 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          progress: false
+
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+          cache-dependency-path: nebula/go.sum
 
       - uses: actions/setup-java@v2
         with:
@@ -25,11 +31,6 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.24.1'
-
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          progress: false
 
       - name: Install the appstore connect key material
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,17 +154,9 @@ jobs:
           draft: true
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: build/app/outputs/bundle/release/MobileNebula.aab
-
-      - name: Upload release iOS app
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ios/MobileNebula.ipa
-          asset_name: MobileNebula.ipa
-          asset_content_type: text/plain
+          files: |
+            build/app/outputs/bundle/release/MobileNebula.aab
+            ios/MobileNebula.ipa
 
       - name: Create Sentry release
         uses: getsentry/action-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           go-version: "1.22"
           cache-dependency-path: nebula/go.sum
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.22
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,16 +141,14 @@ jobs:
           cd android
           fastlane release
 
-      - name: Create Release
+      - name: Create GitHub Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref }}
           draft: true
           prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload release Android app
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          progress: false
+          show-progress: false
 
       - name: Set up Go 1.22
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,9 @@ jobs:
           flutter-version: '3.24.1'
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          progress: false
 
       - name: Install the appstore connect key material
         env:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: "1.22"
           cache-dependency-path: nebula/go.sum
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,10 +12,16 @@ jobs:
     name: Android
     runs-on: macos-latest
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          progress: false
+
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+          cache-dependency-path: nebula/go.sum
 
       - uses: actions/setup-java@v2
         with:
@@ -27,10 +33,6 @@ jobs:
         with:
           flutter-version: '3.24.1'
 
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-            progress: false
       - name: install dependencies
         env:
           TOKEN: ${{ secrets.MACHINE_USER_PAT }}
@@ -86,20 +88,21 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          progress: false
+
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
           go-version: "1.22"
+          cache-dependency-path: nebula/go.sum
 
       - name: Install flutter
         uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.24.1'
-
-      - name: Check out code
-        uses: actions/checkout@v4
-        with:
-          progress: false
 
       - name: install dependencies
         run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Set up Go 1.22
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22"
 
@@ -87,7 +87,7 @@ jobs:
 
     steps:
       - name: Set up Go 1.22
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: "1.22"
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -77,9 +77,9 @@ jobs:
           unzip -p build/app/outputs/apk/debug/app-debug.apks universal.apk > build/app/outputs/apk/debug/app-debug.apk
       - name: Collect debug apk
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: app-debug.apk
+          name: MobileNebulaDebug.apk
           path: build/app/outputs/apk/debug/app-debug.apk
           retention-days: 60
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          progress: false
+          show-progress: false
 
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
@@ -91,7 +91,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         with:
-          progress: false
+          show-progress: false
 
       - name: Set up Go 1.22
         uses: actions/setup-go@v5

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -28,8 +28,9 @@ jobs:
           flutter-version: '3.24.1'
 
       - name: Check out code
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@v4
+        with:
+            progress: false
       - name: install dependencies
         env:
           TOKEN: ${{ secrets.MACHINE_USER_PAT }}
@@ -96,7 +97,9 @@ jobs:
           flutter-version: '3.24.1'
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          progress: false
 
       - name: install dependencies
         run: |


### PR DESCRIPTION
We had some old GitHub actions that were using old node versions.  This updates them, removes some that have been archived/deprecated, and fixes caching of go dependencies.