### PR TITLE
Fix ID used when listening to updates on new sites

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -54,6 +54,7 @@ class MainActivity: FlutterActivity() {
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
         appContext = context
         //TODO: Initializing in the constructor leads to a context lacking info we need, figure out the right way to do this
         sites = Sites(flutterEngine)

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -58,9 +58,7 @@ class MainActivity: FlutterActivity() {
         appContext = context
         //TODO: Initializing in the constructor leads to a context lacking info we need, figure out the right way to do this
         sites = Sites(flutterEngine)
-
-        GeneratedPluginRegistrant.registerWith(flutterEngine)
-
+        
         ui = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL)
         ui!!.setMethodCallHandler { call, result ->
             when(call.method) {

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -100,7 +100,7 @@ class MainActivity: FlutterActivity() {
 
         apiClient = APIClient(context)
 
-        ContextCompat.registerReceiver(context, refreshReceiver, IntentFilter(ACTION_REFRESH_SITES), RECEIVER_NOT_EXPORTED)
+        ContextCompat.registerReceiver(context, refreshReceiver, IntentFilter(ACTION_REFRESH_SITES), ContextCompat.RECEIVER_NOT_EXPORTED)
 
         enqueueDNUpdater()
     }

--- a/lib/models/Site.dart
+++ b/lib/models/Site.dart
@@ -93,20 +93,22 @@ class Site {
     this.rawConfig = rawConfig;
     this.lastManagedUpdate = lastManagedUpdate;
 
-    _updates = EventChannel('net.defined.nebula/$id');
-    _updates.receiveBroadcastStream().listen((d) {
-      try {
-        _updateFromJson(d);
-        _change.add(null);
-      } catch (err) {
-        //TODO: handle the error
-        print(err);
-      }
-    }, onError: (err) {
-      _updateFromJson(err.details);
-      var error = err as PlatformException;
-      _change.addError(error.message ?? 'An unexpected error occurred');
-    });
+    if (id != null) {
+      _updates = EventChannel('net.defined.nebula/$id');
+      _updates.receiveBroadcastStream().listen((d) {
+        try {
+          _updateFromJson(d);
+          _change.add(null);
+        } catch (err) {
+          //TODO: handle the error
+          print(err);
+        }
+      }, onError: (err) {
+        _updateFromJson(err.details);
+        var error = err as PlatformException;
+        _change.addError(error.message ?? 'An unexpected error occurred');
+      });
+    }
   }
 
   factory Site.fromJson(Map<String, dynamic> json) {

--- a/lib/models/Site.dart
+++ b/lib/models/Site.dart
@@ -93,22 +93,20 @@ class Site {
     this.rawConfig = rawConfig;
     this.lastManagedUpdate = lastManagedUpdate;
 
-    if (id != null) {
-      _updates = EventChannel('net.defined.nebula/$id');
-      _updates.receiveBroadcastStream().listen((d) {
-        try {
-          _updateFromJson(d);
-          _change.add(null);
-        } catch (err) {
-          //TODO: handle the error
-          print(err);
-        }
-      }, onError: (err) {
-        _updateFromJson(err.details);
-        var error = err as PlatformException;
-        _change.addError(error.message ?? 'An unexpected error occurred');
-      });
-    }
+    _updates = EventChannel('net.defined.nebula/${this.id}');
+    _updates.receiveBroadcastStream().listen((d) {
+      try {
+        _updateFromJson(d);
+        _change.add(null);
+      } catch (err) {
+        //TODO: handle the error
+        print(err);
+      }
+    }, onError: (err) {
+      _updateFromJson(err.details);
+      var error = err as PlatformException;
+      _change.addError(error.message ?? 'An unexpected error occurred');
+    });
   }
 
   factory Site.fromJson(Map<String, dynamic> json) {


### PR DESCRIPTION
This should avoid the errors we've been seeing in Sentry of:

```
MissingPluginException(No implementation found for method listen on channel net.defined.nebula/null)
```

To test, start up the mobile app in an android phone or emulator, tap the plus button to add a new site, and verify that no error log is shown.

Note: we still get a similar error when tapping the "Good Site" or "Bad Site" in debug, but I believe that is because it's being created too quickly before the EventChannel has a chance to be set up.  Adding a site manually does not trigger the error.