### PR TITLE
Default listen.host to IPv6 addresses

### DIFF
--- a/nebula/config.go
+++ b/nebula/config.go
@@ -30,7 +30,7 @@ func newConfig() *config {
 			Hosts:    []string{},
 		},
 		Listen: configListen{
-			Host:  "0.0.0.0",
+			Host:  "[::]",
 			Port:  4242,
 			Batch: 64,
 		},


### PR DESCRIPTION
This will only affect new configurations, but should improve connectivity on mobile networks.