### PR TITLE
Fix deep links

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -94,46 +94,42 @@ class _AppState extends State<App> {
       ),
     );
 
-    return MaterialApp(
-      theme: brightness == Brightness.light ? lightTheme : darkTheme,
-      home: Scaffold(
-        body: PlatformProvider(
-          //initialPlatform: initialPlatform,
-          builder: (context) => PlatformApp(
-            debugShowCheckedModeBanner: false,
-            localizationsDelegates: <LocalizationsDelegate<dynamic>>[
-              DefaultMaterialLocalizations.delegate,
-              DefaultWidgetsLocalizations.delegate,
-              DefaultCupertinoLocalizations.delegate,
-            ],
-            title: 'Nebula',
-            material: (_, __) {
-              return new MaterialAppData(
-                themeMode: brightness == Brightness.light ? ThemeMode.light : ThemeMode.dark,
-              );
-            },
-            cupertino: (_, __) => CupertinoAppData(
-              theme: CupertinoThemeData(brightness: brightness),
-            ),
-            onGenerateRoute: (settings) {
-              if (settings.name == '/') {
-                return platformPageRoute(context: context, builder: (context) => MainScreen(this.dnEnrolled));
-              }
-
-              final uri = Uri.parse(settings.name!);
-              if (uri.path == EnrollmentScreen.routeName) {
-                // TODO: maybe implement this as a dialog instead of a page, you can stack multiple enrollment screens which is annoying in dev
-                return platformPageRoute(
-                  context: context,
-                  builder: (context) =>
-                      EnrollmentScreen(code: EnrollmentScreen.parseCode(settings.name!), stream: this.dnEnrolled),
-                );
-              }
-
-              return null;
-            },
-          ),
+    return PlatformProvider(
+      settings: PlatformSettingsData(iosUsesMaterialWidgets: true),
+      builder: (context) => PlatformApp(
+        debugShowCheckedModeBanner: false,
+        localizationsDelegates: <LocalizationsDelegate<dynamic>>[
+          DefaultMaterialLocalizations.delegate,
+          DefaultWidgetsLocalizations.delegate,
+          DefaultCupertinoLocalizations.delegate,
+        ],
+        title: 'Nebula',
+        material: (_, __) {
+          return new MaterialAppData(
+            themeMode: brightness == Brightness.light ? ThemeMode.light : ThemeMode.dark,
+            theme: brightness == Brightness.light ? lightTheme : darkTheme,
+          );
+        },
+        cupertino: (_, __) => CupertinoAppData(
+          theme: CupertinoThemeData(brightness: brightness),
         ),
+        onGenerateRoute: (settings) {
+          if (settings.name == '/') {
+            return platformPageRoute(context: context, builder: (context) => MainScreen(this.dnEnrolled));
+          }
+
+          final uri = Uri.parse(settings.name!);
+          if (uri.path == EnrollmentScreen.routeName) {
+            // TODO: maybe implement this as a dialog instead of a page, you can stack multiple enrollment screens which is annoying in dev
+            return platformPageRoute(
+              context: context,
+              builder: (context) =>
+                  EnrollmentScreen(code: EnrollmentScreen.parseCode(settings.name!), stream: this.dnEnrolled),
+            );
+          }
+
+          return null;
+        },
       ),
     );
   }


### PR DESCRIPTION
When last updating flutter, I wrapped our `PlatformProvider` with a `MaterialApp`, which was the wrong approach to getting material widgets working in iOS.  Instead, I should have used `settings: PlatformSettingsData(iosUsesMaterialWidgets: true)`, which is what I've done here.  Testing on my iOS device has shown that deep links from a Managed Nebula account now works correctly.