### PR TITLE
Set ConfigItem label text style correctly

### DIFF
--- a/lib/components/config/ConfigItem.dart
+++ b/lib/components/config/ConfigItem.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile_nebula/services/utils.dart';
@@ -25,7 +27,12 @@ class ConfigItem extends StatelessWidget {
         child: Row(
           crossAxisAlignment: crossAxisAlignment,
           children: <Widget>[
-            Container(width: labelWidth, child: label),
+            Container(
+                width: labelWidth,
+                child: Platform.isAndroid
+                    ? label
+                    : DefaultTextStyle(
+                        style: CupertinoTheme.of(context).textTheme.textStyle, child: Container(child: label))),
             Expanded(child: content),
           ],
         ));

--- a/lib/components/config/ConfigPageItem.dart
+++ b/lib/components/config/ConfigPageItem.dart
@@ -45,7 +45,7 @@ class ConfigPageItem extends StatelessWidget {
       onPressed: this.disabled ? null : onPressed,
       color: Utils.configItemBackground(context),
       child: Container(
-          padding: EdgeInsets.only(left: 15),
+          padding: EdgeInsets.only(left: 15, right: 15),
           constraints: BoxConstraints(minHeight: Utils.minInteractiveSize, minWidth: double.infinity),
           child: Row(
             crossAxisAlignment: crossAxisAlignment,


### PR DESCRIPTION
This sets the label text style of `ConfigItem` correctly, to match the style of `ConfigPageItem`.  I'm not sure why this was working before, honestly.  There's probably a lot of cleanup we could/should do here, but this seems like a decent enough quick-and-dirty fix.

And fixes a padding issue on the config item rows.

|Before:|After:|
|----|----|
|![image](https://github.com/user-attachments/assets/6edc09a9-75b9-4485-89e5-4d0aa0f92353)|![image](https://github.com/user-attachments/assets/593b58a4-a0e5-4a19-a061-3020b619828d)|