### PR TITLE
Fetch more commits for Sentry releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           show-progress: false
+          fetch-depth: 25 # For sentry releases
 
       - name: Set up Go 1.22
         uses: actions/setup-go@v5


### PR DESCRIPTION
We're getting an error in our release job because sentry can't find commits to associate with a release.  So this will fetch the last 25 commits instead of just the last one.

The error we're seeing:

> error: Could not find the SHA of the previous release in the git history. If you limit the clone depth, try to increase it. Otherwise, it means that the commit we are looking for was amended or squashed and cannot be retrieved. Use --ignore-missing flag to skip it and create a new release with the default commits count.