### PR TITLE
Fix ConfigItem font size

### DIFF
--- a/lib/components/config/ConfigItem.dart
+++ b/lib/components/config/ConfigItem.dart
@@ -20,6 +20,13 @@ class ConfigItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var textStyle;
+    if (Platform.isAndroid) {
+      textStyle = Theme.of(context).textTheme.labelLarge!.copyWith(fontWeight: FontWeight.normal);
+    } else {
+      textStyle = CupertinoTheme.of(context).textTheme.textStyle;
+    }
+
     return Container(
         color: Utils.configItemBackground(context),
         padding: EdgeInsets.only(top: 2, bottom: 2, left: 15, right: 20),
@@ -27,17 +34,8 @@ class ConfigItem extends StatelessWidget {
         child: Row(
           crossAxisAlignment: crossAxisAlignment,
           children: <Widget>[
-            Container(
-                width: labelWidth,
-                child: Platform.isAndroid
-                    ? label
-                    : DefaultTextStyle(
-                        style: CupertinoTheme.of(context).textTheme.textStyle, child: Container(child: label))),
-            Expanded(
-                child: Platform.isAndroid
-                    ? content
-                    : DefaultTextStyle(
-                        style: CupertinoTheme.of(context).textTheme.textStyle, child: Container(child: content))),
+            Container(width: labelWidth, child: DefaultTextStyle(style: textStyle, child: Container(child: label))),
+            Expanded(child: DefaultTextStyle(style: textStyle, child: Container(child: content))),
           ],
         ));
   }

--- a/lib/components/config/ConfigItem.dart
+++ b/lib/components/config/ConfigItem.dart
@@ -22,7 +22,7 @@ class ConfigItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
         color: Utils.configItemBackground(context),
-        padding: EdgeInsets.only(top: 2, bottom: 2, left: 15, right: 10),
+        padding: EdgeInsets.only(top: 2, bottom: 2, left: 15, right: 20),
         constraints: BoxConstraints(minHeight: Utils.minInteractiveSize),
         child: Row(
           crossAxisAlignment: crossAxisAlignment,

--- a/lib/components/config/ConfigItem.dart
+++ b/lib/components/config/ConfigItem.dart
@@ -33,7 +33,11 @@ class ConfigItem extends StatelessWidget {
                     ? label
                     : DefaultTextStyle(
                         style: CupertinoTheme.of(context).textTheme.textStyle, child: Container(child: label))),
-            Expanded(child: content),
+            Expanded(
+                child: Platform.isAndroid
+                    ? content
+                    : DefaultTextStyle(
+                        style: CupertinoTheme.of(context).textTheme.textStyle, child: Container(child: content))),
           ],
         ));
   }


### PR DESCRIPTION
And align config items on the right.


|Before:|After:|Android after:|
|----|----|----|
|![image](https://github.com/user-attachments/assets/fb13c199-209e-4d94-b218-45d775cf2406)|![image](https://github.com/user-attachments/assets/cb1d53f8-eda3-46d6-8c85-7a31f99fe804)|![image](https://github.com/user-attachments/assets/016b9810-12ac-4686-9f27-9f9b0e435309)|

(Android has always had some mismatched text sizes there...)