### PR TITLE
Fix system brightness setting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -64,6 +64,16 @@ class _AppState extends State<App> {
       });
     });
 
+    // Listen to changes to the system brightness mode, update accordingly
+    var dispatcher = SchedulerBinding.instance.platformDispatcher;
+    dispatcher.onPlatformBrightnessChanged = () {
+      if (settings.useSystemColors) {
+        setState(() {
+          brightness = dispatcher.platformBrightness;
+        });
+      }
+    };
+
     super.initState();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -65,7 +65,7 @@ class _AppState extends State<App> {
     });
 
     // Listen to changes to the system brightness mode, update accordingly
-    var dispatcher = SchedulerBinding.instance.platformDispatcher;
+    final dispatcher = SchedulerBinding.instance.platformDispatcher;
     dispatcher.onPlatformBrightnessChanged = () {
       if (settings.useSystemColors) {
         setState(() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,7 +56,9 @@ class _AppState extends State<App> {
     //TODO: wait until settings is ready?
     settings.onChange().listen((_) {
       setState(() {
-        if (!settings.useSystemColors) {
+        if (settings.useSystemColors) {
+          brightness = SchedulerBinding.instance.platformDispatcher.platformBrightness;
+        } else {
           brightness = settings.darkMode ? Brightness.dark : Brightness.light;
         }
       });


### PR DESCRIPTION
This fixes two issues:

1) Assume the system is set to dark mode.  Previously, if you disabled system color in the app settings, then changed the dark mode switch to off, then turned system color back on, the app would stay light.  Now, it will respect the system color correctly.

2) Previously the app would not change color if the system mode was changed.  Now it listens for system brightness changes, and updates accordingly, if the setting for using system color is turned on.