### PR TITLE
Allow saving invalid sites

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -95,9 +95,6 @@ class SiteList(context: Context) {
                 try {
                     val site = Site(context, siteDir)
 
-                    // Make sure we can load the private key
-                    site.getKey(context)
-
                     // Make sure we can load the DN credentials if managed
                     if (site.managed) {
                         site.getDNCredentials(context)

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -397,8 +397,8 @@ struct IncomingSite: Codable {
     var id: String
     var staticHostmap: Dictionary<String, StaticHosts>
     var unsafeRoutes: [UnsafeRoute]?
-    var cert: String
-    var ca: String
+    var cert: String?
+    var ca: String?
     var lhDuration: Int
     var port: Int
     var mtu: Int?


### PR DESCRIPTION
Closes https://github.com/DefinedNet/mobile_nebula/issues/191

@nbrownus would like us to be able to save an invalid site, as a way of saving partial progress and then fixing issues later on, so that's what this PR does, for both Android and iOS.  To test, add a site, give it a name, and press save.  You should be taken to a list of sites, including the newly created invalid site.