### PR TITLE
Add PrimaryButton component

### DIFF
--- a/lib/components/buttons/PrimaryButton.dart
+++ b/lib/components/buttons/PrimaryButton.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class PrimaryButton extends StatelessWidget {
+  const PrimaryButton({Key? key, required this.child, this.onPressed}) : super(key: key);
+
+  final Widget child;
+  final GestureTapCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    if (Platform.isAndroid) {
+      return FilledButton(
+          onPressed: onPressed,
+          child: child,
+          style: FilledButton.styleFrom(backgroundColor: Theme.of(context).colorScheme.primary));
+    } else {
+      // Workaround for https://github.com/flutter/flutter/issues/161590
+      final themeData = CupertinoTheme.of(context);
+      return CupertinoTheme(
+          data: themeData.copyWith(primaryColor: CupertinoColors.white),
+          child: CupertinoButton(
+              child: child, onPressed: onPressed, color: CupertinoColors.secondaryLabel.resolveFrom(context)));
+    }
+  }
+}

--- a/lib/screens/siteConfig/AddCertificateScreen.dart
+++ b/lib/screens/siteConfig/AddCertificateScreen.dart
@@ -15,6 +15,7 @@ import 'package:mobile_nebula/screens/siteConfig/ScanQRScreen.dart';
 import 'package:mobile_nebula/services/share.dart';
 import 'package:mobile_nebula/services/utils.dart';
 
+import '../../components/buttons/PrimaryButton.dart';
 import 'CertificateDetailsScreen.dart';
 
 class CertificateResult {
@@ -152,9 +153,8 @@ class _AddCertificateScreenState extends State<AddCertificateScreen> {
           padding: EdgeInsets.only(top: 20, bottom: 10, left: 10, right: 10),
           child: SizedBox(
               width: double.infinity,
-              child: PlatformElevatedButton(
+              child: PrimaryButton(
                   child: Text('Show/Import Private Key'),
-                  color: CupertinoColors.secondaryLabel.resolveFrom(context),
                   onPressed: () => Utils.confirmDelete(context, 'Show/Import Private Key?', () {
                         setState(() {
                           showKey = true;


### PR DESCRIPTION
Android:

|Before Light|Before Dark|After Light|After Dark|
|---|---|---|---|
|<img width="425" alt="Android Studio 2025-01-16 09 47 08" src="https://github.com/user-attachments/assets/c106bcd1-a27a-4665-bb50-11d83d386e36" />|<img width="420" alt="Android Studio 2025-01-16 09 47 32" src="https://github.com/user-attachments/assets/9c6611d5-658d-4da1-86d9-e1702d22c4d7" />|<img width="431" alt="Android Studio 2025-01-16 10 37 43" src="https://github.com/user-attachments/assets/3f6c17bf-530a-4a0e-bcd0-c3c00e6b0d07" />|<img width="425" alt="Android Studio 2025-01-16 10 37 16" src="https://github.com/user-attachments/assets/0392b10d-0cb0-409b-b589-667cfc2074b6" />|

iOS:
No changes
