### PR TITLE
Fix iOS 16 support

### DIFF
--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -62,7 +62,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 }
                 self.site = try Site(manager: foundManager)
             } else {
-                // The downside here is that a new vpn profile is created each time it starts
+                // This does not save the manager with the site, which means we cannot update the
+                // vpn profile name when updates happen (rare).
                 self.site = try Site(proto: self.protocolConfiguration as! NETunnelProviderProtocol)
             }
             config = try self.site!.getConfig()

--- a/ios/Runner/DNUpdate.swift
+++ b/ios/Runner/DNUpdate.swift
@@ -63,7 +63,10 @@ class DNUpdater {
                 return
             }
             
-            newSite?.save(manager: site.manager) { error in
+            let siteManager = site.manager
+            let shouldSaveToManager = siteManager != nil || ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 17, minorVersion: 0, patchVersion: 0))
+            
+            newSite?.save(manager: site.manager, saveToManager: shouldSaveToManager) { error in
                 if (error != nil) {
                     self.log.error("failed to save update: \(error!.localizedDescription, privacy: .public)")
                 }


### PR DESCRIPTION
In older versions of iOS, it's not possible to call `NETunnelProviderManager.loadAllFromPreferences()` from inside the network extension process.  We were seeing `NETunnelProviderManager objects cannot be instantiated from NEProvider processes` errors in iOS 16.  It's unclear exactly when the change happened to allow it, but as far as we can tell it was in iOS 17. 

To Test:
1. On a real device running iOS 16, ensure that enrolling as a Managed Nebula host works correctly.
2. Start the site.
3. Update the host in the admin panel and wait at least 15 minutes for a `checkForUpdate` from the mobile client.  You should get a `Host renewed` audit log for the host.  
4. Verify that there's a log for "Reloading Nebula" in the mobile host, and that it has an up-to-date config.