### PR TITLE
Add Changelog to About screen

### DIFF
--- a/lib/screens/AboutScreen.dart
+++ b/lib/screens/AboutScreen.dart
@@ -62,13 +62,14 @@ class _AboutScreenState extends State<AboutScreen> {
               content: _buildText(flutterVersion['dartSdkVersion'] ?? 'Unknown')),
         ]),
         ConfigSection(children: <Widget>[
-          //TODO: wire up these other pages
-//          ConfigPageItem(label: Text('Changelog'), labelWidth: 300, onPressed: () => Utils.launchUrl('https://defined.net/mobile/changelog', context)),
+          ConfigPageItem(
+              label: Text('Changelog'),
+              labelWidth: 300,
+              onPressed: () => Utils.launchUrl('https://docs.defined.net/dnclient-changelog/', context)),
           ConfigPageItem(
               label: Text('Privacy policy'),
               labelWidth: 300,
               onPressed: () => Utils.launchUrl('https://www.defined.net/privacy/', context)),
-//          ConfigPageItem(label: Text('Licenses'), labelWidth: 300, onPressed: () => Utils.launchUrl('https://defined.net/mobile/license', context)),
         ]),
         Padding(
             padding: EdgeInsets.only(top: 20),


### PR DESCRIPTION
Fixes an about comment:

https://github.com/DefinedNet/mobile_nebula/blob/f290a71b9423949d86bc82678ce8e13fdd7d8324/lib/screens/AboutScreen.dart#L65-L72

This adds a link to https://docs.defined.net/dnclient-changelog/ to track the mobile app changelogs. 

I initially was linking to the app store pages for both platforms directly, but providing the full picture seems more prudent.