### PR TITLE
Migrate from `colorScheme.background` to `colorScheme.surface`

### DIFF
--- a/lib/services/theme.dart
+++ b/lib/services/theme.dart
@@ -346,7 +346,7 @@ class MaterialTheme {
           bodyColor: colorScheme.onSurface,
           displayColor: colorScheme.onSurface,
         ),
-        scaffoldBackgroundColor: colorScheme.background,
+        scaffoldBackgroundColor: colorScheme.surface,
         canvasColor: colorScheme.surface,
       );
 


### PR DESCRIPTION
No visible changes.

This fixes a deprecated api usage lint

```
 /// A color that typically appears behind scrollable content.
  @Deprecated(
    'Use surface instead. '
    'This feature was deprecated after v3.18.0-0.1.pre.'
  )
  Color get background => _background ?? surface;
```

^ adjusting due to this decorator for `colorScheme.background`.