### PR TITLE
Use platform-specific canvas color for SimplePage + platform-specific icons

### DIFF
--- a/lib/components/SimplePage.dart
+++ b/lib/components/SimplePage.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart' as cupertino;
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:mobile_nebula/services/utils.dart';
@@ -99,7 +98,7 @@ class SimplePage extends StatelessWidget {
     }
 
     return PlatformScaffold(
-        backgroundColor: cupertino.CupertinoColors.systemGroupedBackground.resolveFrom(context),
+        backgroundColor: Theme.of(context).canvasColor,
         appBar: PlatformAppBar(
           title: title,
           leading: leadingAction != null ? leadingAction : Utils.leadingBackWidget(context),

--- a/lib/screens/MainScreen.dart
+++ b/lib/screens/MainScreen.dart
@@ -157,7 +157,7 @@ class _MainScreenState extends State<MainScreen> {
       trailingActions: <Widget>[
         PlatformIconButton(
           padding: EdgeInsets.zero,
-          icon: Icon(Icons.menu, size: 28.0),
+          icon: Icon(Icons.adaptive.more, size: 28.0),
           onPressed: () => Utils.openPage(context, (_) => SettingsScreen(widget.dnEnrollStream)),
         ),
       ],


### PR DESCRIPTION
This uses the `Theme.of(context)` to set the background for SimplePage in a cross-platform respecting way, instead of hardcoding to a cupertino value.

It also uses an icon for the "more" menu that is cross-platform adjusting as well.

| Before | After |
|--------|--------|
| ![Screenshot_1737669862](https://github.com/user-attachments/assets/179aabb4-8da4-4d51-a82a-1dc421942a33) | ![Screenshot_1737669848](https://github.com/user-attachments/assets/fd78f10d-2434-4d58-8708-289f0d0d87a7) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-23 at 16 04 24](https://github.com/user-attachments/assets/640f6287-5c21-4555-a5ed-f0194514de9e) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-23 at 16 04 11](https://github.com/user-attachments/assets/c93f83fd-f81d-467d-a617-d0875f3ac373) |

## Dark mode **after**
| Android | iOS |
|--------|--------|
| ![Screenshot_1737670925](https://github.com/user-attachments/assets/062ba92f-f2eb-4048-a779-c301bbbc6aad) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-23 at 16 23 43](https://github.com/user-attachments/assets/06429da5-a7c0-4dcb-b785-c603c92e1b89) | 
