### PR TITLE
Fix SimplePage background color variable

### DIFF
--- a/lib/components/SimplePage.dart
+++ b/lib/components/SimplePage.dart
@@ -98,7 +98,7 @@ class SimplePage extends StatelessWidget {
     }
 
     return PlatformScaffold(
-        backgroundColor: Theme.of(context).canvasColor,
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         appBar: PlatformAppBar(
           title: title,
           leading: leadingAction != null ? leadingAction : Utils.leadingBackWidget(context),


### PR DESCRIPTION
These variables evaluate to the same, but `scaffoldBackgroundColor` seems the more apt variable to pass to `PlatformScaffold`!