### PR TITLE
Add text wrap toggle to logs screen

### DIFF
--- a/lib/screens/SiteLogsScreen.dart
+++ b/lib/screens/SiteLogsScreen.dart
@@ -45,6 +45,31 @@ class _SiteLogsScreenState extends State<SiteLogsScreen> {
 
     return SimplePage(
       title: title,
+      trailingActions: [
+        Padding(
+          padding: const EdgeInsets.only(right: 8),
+          child: IconButton.filledTonal(
+            // Fixes enormous button on iOS, this *should* be the default, but it seems to be overridden.
+            iconSize: 24,
+            style: Platform.isIOS
+                ? IconButton.styleFrom(
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                    // Match background when not selected on iOS
+                    backgroundColor: settings.logWrap ? null : Colors.transparent,
+                  )
+                : null,
+            isSelected: settings.logWrap,
+            tooltip: "Turn ${settings.logWrap ? "off" : "on"} text wrapping",
+            selectedIcon: const Icon(Icons.wrap_text_outlined),
+            icon: const Icon(Icons.wrap_text),
+            onPressed: () => {
+              setState(() {
+                settings.logWrap = !settings.logWrap;
+              })
+            },
+          ),
+        )
+      ],
       scrollable: SimpleScrollable.both,
       scrollController: controller,
       onRefresh: () async {

--- a/lib/screens/SiteLogsScreen.dart
+++ b/lib/screens/SiteLogsScreen.dart
@@ -45,31 +45,7 @@ class _SiteLogsScreenState extends State<SiteLogsScreen> {
 
     return SimplePage(
       title: title,
-      trailingActions: [
-        Padding(
-          padding: const EdgeInsets.only(right: 8),
-          child: IconButton.filledTonal(
-            // Fixes enormous button on iOS, this *should* be the default, but it seems to be overridden.
-            iconSize: 24,
-            style: Platform.isIOS
-                ? IconButton.styleFrom(
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                    // Match background when not selected on iOS
-                    backgroundColor: settings.logWrap ? null : Colors.transparent,
-                  )
-                : null,
-            isSelected: settings.logWrap,
-            tooltip: "Turn ${settings.logWrap ? "off" : "on"} text wrapping",
-            selectedIcon: const Icon(Icons.wrap_text_outlined),
-            icon: const Icon(Icons.wrap_text),
-            onPressed: () => {
-              setState(() {
-                settings.logWrap = !settings.logWrap;
-              })
-            },
-          ),
-        )
-      ],
+      trailingActions: [Padding(padding: const EdgeInsets.only(right: 8), child: _buildTextWrapToggle())],
       scrollable: SimpleScrollable.both,
       scrollController: controller,
       onRefresh: () async {
@@ -87,6 +63,37 @@ class _SiteLogsScreenState extends State<SiteLogsScreen> {
           child: SelectableText(logs.trim(), style: TextStyle(fontFamily: 'RobotoMono', fontSize: 14))),
       bottomBar: _buildBottomBar(),
     );
+  }
+
+  Widget _buildTextWrapToggle() {
+    return Platform.isIOS
+        ? Tooltip(
+            message: "Turn ${settings.logWrap ? "off" : "on"} text wrapping",
+            child: CupertinoButton.tinted(
+              // Use the default tint when enabled, match the background when not.
+              color: settings.logWrap ? null : CupertinoColors.systemBackground,
+              sizeStyle: CupertinoButtonSize.small,
+              borderRadius: const BorderRadius.all(Radius.circular(8)),
+              child: const Icon(Icons.wrap_text),
+              onPressed: () => {
+                setState(() {
+                  settings.logWrap = !settings.logWrap;
+                })
+              },
+            ),
+          )
+        : IconButton.filledTonal(
+            isSelected: settings.logWrap,
+            tooltip: "Turn ${settings.logWrap ? "off" : "on"} text wrapping",
+            // The variants of wrap_text seem to be the same, but this seems most correct.
+            selectedIcon: const Icon(Icons.wrap_text_outlined),
+            icon: const Icon(Icons.wrap_text),
+            onPressed: () => {
+              setState(() {
+                settings.logWrap = !settings.logWrap;
+              })
+            },
+          );
   }
 
   Widget _buildBottomBar() {


### PR DESCRIPTION
Speaks to https://github.com/DefinedNet/mobile_nebula/issues/12

I've also included stateful tooltips for the button.

Sorry for the lack of logs in the iOS screenshot, I'm not sure why I'm not able to generate a log file in the simulator.

| No wrap | Wrap |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-24 at 15 22 49](https://github.com/user-attachments/assets/fc662209-0c88-4219-a470-6e8f7116438e) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-24 at 15 22 51](https://github.com/user-attachments/assets/6ddf27ca-9c41-41a0-b3fa-71774e22d000) |
| ![Screenshot_1737753559](https://github.com/user-attachments/assets/569b6202-a475-4480-9a4c-8bab56e34711) | ![Screenshot_1737753561](https://github.com/user-attachments/assets/b0deeb9b-8a4c-4d28-9ecd-16a451f66aee) | 

