### PR TITLE
Fix padding for placeholder in ConfigTextItem

### DIFF
--- a/lib/components/config/ConfigTextItem.dart
+++ b/lib/components/config/ConfigTextItem.dart
@@ -1,8 +1,4 @@
-import 'dart:io';
-
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
-import 'package:mobile_nebula/components/SpecialTextField.dart';
 
 class ConfigTextItem extends StatelessWidget {
   const ConfigTextItem(
@@ -15,14 +11,13 @@ class ConfigTextItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-        padding: Platform.isAndroid ? EdgeInsets.all(5) : EdgeInsets.zero,
-        child: SpecialTextField(
-            autocorrect: false,
-            minLines: 3,
-            maxLines: 10,
-            placeholder: placeholder,
-            style: style,
-            controller: controller));
+    return CupertinoTextFormFieldRow(
+      autocorrect: false,
+      minLines: 3,
+      maxLines: 10,
+      placeholder: placeholder,
+      style: style,
+      controller: controller,
+    );
   }
 }


### PR DESCRIPTION
Fixes #242 

| Before | After |
|--------|--------|
| <img width="354" alt="image" src="https://github.com/user-attachments/assets/1e1a0e5b-49bd-4d7b-92b6-4029361711de" /> | <img width="361" alt="image" src="https://github.com/user-attachments/assets/e098cb11-f2c6-4401-847b-ae1214309749" /> |
| <img width="379" alt="image" src="https://github.com/user-attachments/assets/69eae924-bd37-4805-8053-6f80a6fb96bf" /> | <img width="380" alt="image" src="https://github.com/user-attachments/assets/f9301cc5-19d3-411a-817f-d8138899070b" /> | 