### PR TITLE
Add a minHeight for the config rows

### DIFF
--- a/lib/components/config/ConfigItem.dart
+++ b/lib/components/config/ConfigItem.dart
@@ -30,7 +30,7 @@ class ConfigItem extends StatelessWidget {
     return Container(
         color: Utils.configItemBackground(context),
         padding: EdgeInsets.symmetric(vertical: 6, horizontal: 15),
-        constraints: BoxConstraints(minHeight: Utils.minInteractiveSize),
+        constraints: BoxConstraints(minHeight: Utils.minConfigItemHeight),
         child: Row(
           crossAxisAlignment: crossAxisAlignment,
           children: <Widget>[

--- a/lib/components/config/ConfigPageItem.dart
+++ b/lib/components/config/ConfigPageItem.dart
@@ -46,7 +46,7 @@ class ConfigPageItem extends StatelessWidget {
       color: Utils.configItemBackground(context),
       child: Container(
           padding: EdgeInsets.symmetric(vertical: 6, horizontal: 15),
-          constraints: BoxConstraints(minHeight: Utils.minInteractiveSize, minWidth: double.infinity),
+          constraints: BoxConstraints(minHeight: Utils.minConfigItemHeight, minWidth: double.infinity),
           child: Row(
             crossAxisAlignment: crossAxisAlignment,
             children: <Widget>[

--- a/lib/services/utils.dart
+++ b/lib/services/utils.dart
@@ -16,6 +16,8 @@ class Utils {
     return CupertinoColors.systemGroupedBackground.resolveFrom(context);
   }
 
+  static const double minConfigItemHeight = 54;
+
   /// The background color for a config item
   static Color configItemBackground(BuildContext context) {
     return CupertinoColors.secondarySystemGroupedBackground.resolveFrom(context);


### PR DESCRIPTION
I'm not sure this is the move. I think I like before more.

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-31 at 14 32 53](https://github.com/user-attachments/assets/a43ac541-e495-49a5-bcc4-c415e87fe526) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-31 at 14 31 38](https://github.com/user-attachments/assets/06c28174-099d-4ffc-9f1f-e85e0560f631) |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-31 at 14 32 51](https://github.com/user-attachments/assets/eb4df939-bf9a-4ad1-acc2-1aecc2669a61) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-31 at 14 31 36](https://github.com/user-attachments/assets/44ab9c31-d525-42e4-8828-21eb100e3f96) |
| ![Screenshot_1738355567](https://github.com/user-attachments/assets/84090d48-94a4-4ebe-88d3-eba7ca2ee395) |![Screenshot_1738355509](https://github.com/user-attachments/assets/22f6f5b6-6cc6-44d5-940c-9f8fb87eee11) |
|  ![Screenshot_1738355564](https://github.com/user-attachments/assets/ada53e41-804f-40d4-b7d8-dc09154e5ca1) | ![Screenshot_1738355507](https://github.com/user-attachments/assets/86103bf2-40c2-4e7b-a0bf-cd3879b997dd) | 