### PR TITLE
Add Swift formatting locally and in CI

### DIFF
--- a/.github/workflows/swiftfmt.yml
+++ b/.github/workflows/swiftfmt.yml
@@ -17,5 +17,6 @@ jobs:
         with:
           show-progress: false
 
-      - name: Check formating
-        run: swiftformat --lint . --reporter github-actions-log
+    # Re-enable in follow-up PR that does the formatting.
+    #   - name: Check formating
+    #     run: swiftformat --lint . --reporter github-actions-log

--- a/.github/workflows/swiftfmt.yml
+++ b/.github/workflows/swiftfmt.yml
@@ -1,0 +1,21 @@
+name: Swift format
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '.github/workflows/swiftfmt.yml'
+      - '**.swift'
+jobs:
+  swiftfmt:
+    name: Run swift format
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Check formating
+        run: swiftformat --lint . --reporter github-actions-log

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 Install all of the following things:
 
 - [`xcode`](https://apps.apple.com/us/app/xcode/)
+- [`swiftformat`](https://github.com/nicklockwood/SwiftFormat)
 - [`android-studio`](https://developer.android.com/studio)
 - [`flutter` 3.29.0](https://docs.flutter.dev/get-started/install)
 - [`gomobile`](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile)
@@ -40,6 +41,10 @@ dart format lib/ test/ -l 120
 ```
 
 In Android Studio, set the line length using Preferences -> Editor -> Code Style -> Dart -> Line length, set it to 120.  Enable auto-format with Preferences -> Languages & Frameworks -> Flutter -> Format code on save.
+
+`swiftformat .` can be used to format the `*.swift` code in the repo.
+
+There are several options for editor integrations listed in the source repo: <https://github.com/nicklockwood/SwiftFormat>
 
 
 # Release

--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -1,1 +1,2 @@
 --swiftversion 5
+--exclude Pods,Generated

--- a/ios/.swiftformat
+++ b/ios/.swiftformat
@@ -1,0 +1,1 @@
+--swiftversion 5

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -563,6 +563,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -772,6 +773,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -825,6 +827,7 @@
 				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};


### PR DESCRIPTION
https://github.com/nicklockwood/SwiftFormat automatically formats swift code like how we treat dart and golang.

#254 was a different attempt, but https://github.com/swiftlang/swift-format doesn't support easily ignoring a source folder, and the "is it formatted" command also detects lints.

Refs: 
- https://github.com/swiftlang/swift-format/issues/870
- https://github.com/swiftlang/swift-format/pull/873
- https://github.com/swiftlang/swift-format/issues/931

There's an option to load the tool via Cocoapods, or Swift Package Manager, but I think just allowing users to install via homebrew, or whichever method they wish is best for now.

The actual CI check is disabled, enabled in #257 