### PR TITLE
Git blame ignore PR 263

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # Another big flutter format run
 ed348ab126160e64ba09899c946383ca9e54768c
+
+# Start formatting with swift-format
+4621cbc0006b3c64c8948d920f69b0dc3f503565


### PR DESCRIPTION
This PR adds https://github.com/DefinedNet/mobile_nebula/pull/263 to the `.git-blame-ignore-revs` file to improve git blame and not to attribute code to the formatter.