### PR TITLE
Use material 3 page transitions [android]

### DIFF
--- a/lib/services/theme.dart
+++ b/lib/services/theme.dart
@@ -345,6 +345,12 @@ class MaterialTheme {
     textTheme: textTheme.apply(bodyColor: colorScheme.onSurface, displayColor: colorScheme.onSurface),
     scaffoldBackgroundColor: colorScheme.surface,
     canvasColor: colorScheme.surface,
+    pageTransitionsTheme: PageTransitionsTheme(
+      builders: Map<TargetPlatform, PageTransitionsBuilder>.fromIterable(
+        TargetPlatform.values,
+        value: (_) => const FadeForwardsPageTransitionsBuilder(),
+      ),
+    ),
   );
 
   List<ExtendedColor> get extendedColors => [];


### PR DESCRIPTION
The latest version of flutter (3.29, which we're already using) finally added a decent page transition matching up with the native material 3 transition.  (https://main-api.flutter.dev/flutter/material/FadeForwardsPageTransitionsBuilder-class.html)

To test, fire up the app in android, and navigate around.  