### PR TITLE
Update github runners to use macos 15 / xcode 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build ios and android package
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Check out code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-android:
     name: Android
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
@@ -85,7 +85,7 @@ jobs:
 
   build-ios:
     name: iOS
-    runs-on: macos-latest
+    runs-on: macos-15
 
     steps:
       - name: Check out code

--- a/.github/workflows/swiftfmt.yml
+++ b/.github/workflows/swiftfmt.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   swiftfmt:
     name: Run swift format
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Install all of the following things:
 
-- [`xcode`](https://apps.apple.com/us/app/xcode/)
+- [`xcode`](https://apps.apple.com/us/app/xcode/) - use the version specified by `xcode_select` in `/ios/fastlane/Fastfile`
 - [`android-studio`](https://developer.android.com/studio)
 - [`flutter` 3.29.2](https://docs.flutter.dev/get-started/install)
 - [`gomobile`](https://pkg.go.dev/golang.org/x/mobile/cmd/gomobile)

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -18,6 +18,11 @@ default_platform(:ios)
 platform :ios do
   desc "Push a new beta build to TestFlight"
 
+  before_all do
+    xcode_select("/Applications/Xcode_16.3.0.app")
+  end
+  
+
   lane :build do
     # Do some things like setting up a temporary keystore to host secrets in CI
     setup_ci


### PR DESCRIPTION
According to https://github.com/actions/runner-images#available-images, currently `macos-latest` is pointing to macos 14 images, which come bundled with xcode 15.  Apple now requires xcode 16, which we'll get by updating to `macos-15`.  

This also bumps the version github uses to `16.3` (by default it will stay at 16.0), and adds a note to the README that ideally we should all be using the same version of xcode that is used to build the app that is sent to Apple.

We could get fancier with this, but I don't think it's really necessary right now.  See https://www.polpiella.dev/managing-xcode-installs-using-fastlane for other approaches.