### PR TITLE
Rollback Xcode to 16.2

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -19,9 +19,9 @@ platform :ios do
   desc "Push a new beta build to TestFlight"
 
   before_all do
-    xcode_select("/Applications/Xcode_16.3.0.app")
+    xcode_select("/Applications/Xcode_16.2.0.app")
   end
-  
+
 
   lane :build do
     # Do some things like setting up a temporary keystore to host secrets in CI


### PR DESCRIPTION
This fixes an error with Sentry during build. We could also upgrade Sentry but this was the quickest path to making Mobile Nebula buildable again.

```
[Sentry] Compiling SentryThreadMetadataCache.cpp
Error: static assertion failed due to requirement '!is_const<const sentry::profiling::ThreadMetadataCache::ThreadHandleMetadataPair>::value': std::allocator does not support const types
   95 |   static_assert(!is_const<_Tp>::value, "std::allocator does not support const types");
      |                 ^~~~~~~~~~~~~~~~~~~~~
Error: static assertion failed due to requirement 'is_same<std::allocator<const sentry::profiling::ThreadMetadataCache::ThreadHandleMetadataPair>, std::allocator<int>>::value': [allocator.requirements] states that rebinding an allocator to the same type should result in the original allocator
  378 |   static_assert(is_same<_Alloc, __rebind_alloc<_Traits, typename _Traits::value_type> >::value,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Error: no type named 'value_type' in 'std::allocator<const sentry::profiling::ThreadMetadataCache::ThreadHandleMetadataPair>'
  427 |   static_assert(is_same<typename allocator_type::value_type, value_type>::value,
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
Error: no type named 'type' in 'std::enable_if<false, int>'; 'enable_if' cannot be used to disable this declaration
   28 | using __enable_if_t _LIBCPP_NODEBUG = typename enable_if<_Bp, _Tp>::type;

... snip ...
```

Tested here: https://github.com/DefinedNet/mobile_nebula/actions/runs/14887397322