### PR TITLE
Update mobile_scanner dependency

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,11 +10,11 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - Sentry/HybridSDK (8.42.0)
-  - sentry_flutter (8.12.0):
+  - Sentry/HybridSDK (8.46.0)
+  - sentry_flutter (8.14.2):
     - Flutter
     - FlutterMacOS
-    - Sentry/HybridSDK (= 8.42.0)
+    - Sentry/HybridSDK (= 8.46.0)
   - share_plus (0.0.1):
     - Flutter
   - SwiftyJSON (5.0.2)
@@ -56,16 +56,16 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
 SPEC CHECKSUMS:
-  file_picker: 8272ff2f2365937598e2407f4f2ff55c723f084a
+  file_picker: c79185e70b9b45728cde2a8d8da454e0cb43f287
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  Sentry: 38ed8bf38eab5812787274bf591e528074c19e02
-  sentry_flutter: a72ca0eb6e78335db7c4ddcddd1b9f6c8ed5b764
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
+  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
+  Sentry: da60d980b197a46db0b35ea12cb8f39af48d8854
+  sentry_flutter: 2df8b0aab7e4aba81261c230cbea31c82a62dd1b
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
   SwiftyJSON: f5b1bf1cd8dd53cd25887ac0eabcfd92301c6a5a
-  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
 
 PODFILE CHECKSUM: b44d9de9944d89118a4ff4bfffe1c2dab91de156
 

--- a/lib/screens/siteConfig/ScanQRScreen.dart
+++ b/lib/screens/siteConfig/ScanQRScreen.dart
@@ -152,6 +152,10 @@ class SwitchCameraButton extends StatelessWidget {
             icon = const Icon(Icons.camera_front);
           case CameraFacing.back:
             icon = const Icon(Icons.camera_rear);
+          case CameraFacing.external:
+            icon = const Icon(Icons.usb);
+          case CameraFacing.unknown:
+            icon = const Icon(Icons.device_unknown);
         }
 
         return IconButton(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -316,10 +316,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: "1779bf862cfcf7a142117e707e2230624d42f153ddf51f4cc9f5ba455a2dd01e"
+      sha256: "54005bdea7052d792d35b4fef0f84ec5ddc3a844b250ecd48dc192fb9b4ebc95"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0-beta.4"
+    version: "7.0.1"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -452,26 +452,26 @@ packages:
     dependency: transitive
     description:
       name: sentry
-      sha256: "576ad83415102ba2060142a6701611abc6e67a55af1d7ab339cedd3ba1b0f84c"
+      sha256: "599701ca0693a74da361bc780b0752e1abc98226cf5095f6b069648116c896bb"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.14.2"
   sentry_dart_plugin:
     dependency: "direct main"
     description:
       name: sentry_dart_plugin
-      sha256: "14c298de1be3ba3a6a16d9ce0aad8662b14ca6ed85b8ade234f75b2f3c285edf"
+      sha256: "84436958fa9231e2e716be117a3b31695e54458b9f27039f76d14515e24248a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.4.1"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
-      sha256: dc3761e8659839cc67a18432d9f12e5531affb7ff68e196dbb56846909b5dfdc
+      sha256: "5ba2cf40646a77d113b37a07bd69f61bb3ec8a73cbabe5537b05a7c89d2656f8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.0"
+    version: "8.14.2"
   share_plus:
     dependency: "direct main"
     description:
@@ -719,4 +719,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,9 +36,9 @@ dependencies:
   flutter_svg: ^2.0.10+1
   intl: ^0.19.0
   share_plus: ^10.0.2
-  sentry_flutter: ^8.9.0
-  sentry_dart_plugin: ^2.0.0
-  mobile_scanner: ^7.0.0-beta.3
+  sentry_flutter: ^8.14.2
+  sentry_dart_plugin: ^2.4.1
+  mobile_scanner: ^7.0.1
   path: ^1.9.1
 
 dev_dependencies:


### PR DESCRIPTION
Closes https://github.com/DefinedNet/mobile_nebula/issues/280

This updates us to a stable version of https://github.com/juliansteenbakker/mobile_scanner.  I was able to reproduce the issue referenced on `main`, but after updating it is scanning correctly with my iOS device.

I also needed to update Sentry, as xcode would not build successfully otherwise.