### PR TITLE
Increase the commit fetch depth for releases for sentry's use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   push:
     tags:
       # Only builds for tags with a meaningless build number suffix: v1.0.0-1
-      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
 jobs:
   build:
@@ -15,23 +15,23 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2
         with:
           show-progress: false
-          fetch-depth: 25 # For sentry releases
+          fetch-depth: 75 # For sentry releases
 
       - name: Set up Go 1.22
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #5.3.0
         with:
-          go-version: '1.22'
+          go-version: "1.22"
           cache-dependency-path: nebula/go.sum
 
       - uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 #v4.7.0
         with:
-          distribution: 'zulu'
-          java-version: '17'
+          distribution: "zulu"
+          java-version: "17"
 
       - name: Install flutter
         uses: subosito/flutter-action@f2c4f6686ca8e8d6e6d0f28410eeef506ed66aff #v2.18.0
         with:
-          flutter-version: '3.29.2'
+          flutter-version: "3.29.2"
 
       - name: Setup bundletool for APK generation
         uses: amyu/setup-bundletool@f7a6fdd8e04bb23d2fdf3c2f60c9257a6298a40a


### PR DESCRIPTION
Fixes #284 

Sentry diffs previous commits released when calculating which commits are included in a particular release. This requires that we checkout enough commits to include the last mobile release, which meant that the release workflow was failing when we hadn't released a version in the past 25 commits.