### PR TITLE
Enable tunnels.drop_inactive with 10m timeout

### DIFF
--- a/nebula/config.go
+++ b/nebula/config.go
@@ -13,6 +13,7 @@ type config struct {
 	Logging       configLogging       `yaml:"logging"`
 	Stats         configStats         `yaml:"stats"`
 	Handshakes    configHandshakes    `yaml:"handshakes"`
+	Tunnels       configTunnels       `yaml:"tunnels"`
 	Firewall      configFirewall      `yaml:"firewall"`
 	Relay         configRelay         `yaml:"relay"`
 }
@@ -63,6 +64,10 @@ func newConfig() *config {
 			TryInterval:  "100ms",
 			Retries:      20,
 			WaitRotation: 5,
+		},
+		Tunnels: configTunnels{
+			DropInactive:      true,
+			InactivityTimeout: "10m",
 		},
 		Firewall: configFirewall{
 			Conntrack: configConntrack{
@@ -178,6 +183,11 @@ type configHandshakes struct {
 	TryInterval  string `yaml:"try_interval"`
 	Retries      int    `yaml:"retries"`
 	WaitRotation int    `yaml:"wait_rotation"`
+}
+
+type configTunnels struct {
+	DropInactive      bool   `yaml:"drop_inactive"`
+	InactivityTimeout string `yaml:"inactivity_timeout"`
 }
 
 type configFirewall struct {


### PR DESCRIPTION
This affects unmanaged sites only.

Rendered config of an existing unmanaged site:

<img width="748" height="1664" alt="image" src="https://github.com/user-attachments/assets/b96da358-620f-4cd4-be2b-9cb24c8ee8f1" />

Rendered config of a DN-managed site (this will be turned on via the DN service):

<img width="748" height="1664" alt="image" src="https://github.com/user-attachments/assets/230a7715-f6b9-4170-a539-012ecd1ec5e0" />