### PR TITLE
Update xcode and macos versions to latest for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build ios and android package
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Check out code

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-android:
     name: Android
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2

--- a/.github/workflows/swiftfmt.yml
+++ b/.github/workflows/swiftfmt.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   swiftfmt:
     name: Run swift format
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #4.2.2

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :ios do
   desc "Push a new beta build to TestFlight"
 
   before_all do
-    xcode_select("/Applications/Xcode_16.2.0.app")
+    xcode_select("/Applications/Xcode_26.0.1.app")
   end
 
 


### PR DESCRIPTION
xcode 16.2.0 was no longer available on the macos runners so I bumped everything to the latest version.

Release v0.6.0-2 is tagged from this branch as a test which also includes the 16kb page size for android.

Please let me know if you experience any issues with this build!