### PR TITLE
Don't unbind vpn service comms if failures are reported for a site that is not the active one

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -524,9 +524,13 @@ class MainActivity: FlutterActivity() {
         }
 
         private fun serviceExited(site: SiteContainer, msg: Message) {
-            activeSiteId = null
             site.updater.setState(false, "Disconnected", msg.data.getString("error"))
-            unbindVpnService()
+            if (site.site.id == activeSiteId) {
+                // Only unbind if its the current expected active site since an attempt can be made to start
+                // a site while another is actively running.
+                activeSiteId = null
+                unbindVpnService()
+            }
         }
     }
 

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -72,8 +72,12 @@ class NebulaVpnService : VpnService() {
             if (site!!.id != id) {
                 announceExit(id, "Trying to run nebula but it is already running")
             }
+            return super.onStartCommand(intent, flags, startId)
+        }
 
-            //TODO: can we signal failure?
+        // Make sure we don't accept commands for a different site id
+        if (site != null && site!!.id != id) {
+            announceExit(id, "Command received for a site id that is different from the current active site")
             return super.onStartCommand(intent, flags, startId)
         }
 
@@ -84,7 +88,6 @@ class NebulaVpnService : VpnService() {
 
         if (site!!.cert == null) {
             announceExit(id, "Site is missing a certificate")
-            //TODO: can we signal failure?
             return super.onStartCommand(intent, flags, startId)
         }
 


### PR DESCRIPTION
Ran into a situation on Android when attempting to start a 2nd site multiple times.

First time it would correctly return an error that another site was already running.
Second time it would report the site was initializing and things would be broken from then on.

This change only clears the active running site state and unbinds communication with the vpn service if it was the active site that reported an exit.