### PR TITLE
On ChromeOS, bring dns resolvers from the underlay network into the vpn

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -446,23 +446,28 @@ fun InetAddress.isGlobalUnicast(): Boolean {
         return false
     }
 
-    if (this is Inet4Address) {
-        val address = this.hostAddress
+    try {
+        if (this is Inet4Address) {
+            val address = this.hostAddress
 
-        // Exclude Private IPv4 ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
-        return address != null &&
-                address != "0.0.0.0" &&
-                !isIpv4Private(this.address)
-    } else if (this is Inet6Address) {
-        return true
+            // Exclude Private IPv4 ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+            return address != null &&
+                    address != "0.0.0.0" &&
+                    !isIpv4Private(this.address)
+        } else if (this is Inet6Address) {
+            return true
+        }
+    } catch (err: Exception) {
+        Log.e(TAG, "Caught exception in InetAddress.isGlobalUnicast: $err")
+        return false
     }
 
     return false
 }
 
 fun isIpv4Private(addr: ByteArray): Boolean {
-    if (addr.size < 4) {
-        return true
+    if (addr.size != 4) {
+        throw IllegalArgumentException("addr must be 4 bytes")
     }
 
     val b = addr[0].toInt() and 0xFF


### PR DESCRIPTION
Ran into a situation with modern chromebooks:

```
With "Use secure connections to look up sites" enabled, a dns server is required to be set by the nebula vpn instance.
This is required for any DNS to work but the server defined by the vpn is only used when the DNS provider is set to "Network default" in the settings app, otherwise it's entirely ignored.
 
With "Use secure connections to look up sites" disabled, a dns server is also required and it must actually be a dns server.
The ip address does not have to be within your vpn network range.
```

This change brings along any public dns resolvers from the underlay networks into the vpn if its ChromeOS. A better long term fix is to allow users to also configure the dns servers to use but I expect we would still want this method as a fallback in the event the user hadn't configured any.

Tested on ChromeOS version 138.0.7204.302