### PR TITLE
Allow null groups in a cert, add some line height to site names for the managed widget alignment

### DIFF
--- a/lib/components/SiteItem.dart
+++ b/lib/components/SiteItem.dart
@@ -19,7 +19,7 @@ class SiteItem extends StatelessWidget {
 
   Widget _siteNameWidget(context) {
     final badgeTheme = Theme.of(context).badgeTheme;
-    final nameStyle = TextStyle(fontWeight: FontWeight.w500, fontSize: 16);
+    final nameStyle = TextStyle(fontWeight: FontWeight.w500, fontSize: 16, height: 1.6);
     List<InlineSpan> children = [];
 
     // Add the name

--- a/lib/models/Certificate.dart
+++ b/lib/models/Certificate.dart
@@ -80,7 +80,7 @@ class Certificate {
       details["name"],
       List<String>.from(details['networks'] ?? []),
       List<String>.from(details['unsafeNetworks'] ?? []),
-      List<String>.from(details['groups']),
+      List<String>.from(details['groups'] ?? []),
       details['isCa'],
       DateTime.parse(details['notBefore']),
       DateTime.parse(details['notAfter']),


### PR DESCRIPTION
null groups caused an error when fetching a host list. The managed badge on the home screen had an off alignment when the site name wraps to another line.

Closes #333