### PR TITLE
Add a validating UnsafeRoute.fromYaml factory

### DIFF
--- a/lib/errors/parse_error.dart
+++ b/lib/errors/parse_error.dart
@@ -1,5 +1,5 @@
 class ParseError implements Exception {
-  final String message;
+  String message;
   ParseError(this.message);
 
   @override

--- a/lib/models/unsafe_route.dart
+++ b/lib/models/unsafe_route.dart
@@ -1,8 +1,45 @@
+import 'package:mobile_nebula/errors/parse_error.dart';
+import 'package:mobile_nebula/validators/ip_validator.dart';
+import 'package:yaml/yaml.dart';
+
+import 'cidr.dart';
+
 class UnsafeRoute {
   String? route;
   String? via;
 
   UnsafeRoute({this.route, this.via});
+
+  factory UnsafeRoute.fromYaml(dynamic yaml) {
+    if (yaml is! YamlMap) {
+      throw ParseError('unsafe route was not a map');
+    }
+
+    final unsafeRoute = UnsafeRoute();
+    if (yaml.containsKey('route') && yaml['route'] is String) {
+      try {
+        unsafeRoute.route = CIDR.fromString(yaml['route'] as String).toString();
+      } on ParseError catch (err) {
+        err.message = 'unable to parse CIDR from route: ${err.message}';
+        rethrow;
+      }
+    } else {
+      throw ParseError('route was not a string');
+    }
+
+    if (yaml.containsKey('via') && yaml['via'] is String) {
+      final yamlVia = yaml['via'] as String;
+      var (valid, _) = ipValidator(yamlVia);
+      if (!valid) {
+        throw ParseError('via was not a valid ip address');
+      }
+      unsafeRoute.via = yamlVia;
+    } else {
+      throw ParseError('via was not a string');
+    }
+
+    return unsafeRoute;
+  }
 
   factory UnsafeRoute.fromJson(Map<String, dynamic> json) {
     return UnsafeRoute(route: json['route'], via: json['via']);

--- a/test/models/unsafe_route_test.dart
+++ b/test/models/unsafe_route_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_nebula/errors/parse_error.dart';
+import 'package:mobile_nebula/models/unsafe_route.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('UnsafeRoute.fromYaml', () {
+    var yaml = loadYaml('''
+    route: 10.0.0.0/24
+    via: 100.100.1.1
+    ''');
+    var unsafeRoute = UnsafeRoute.fromYaml(yaml);
+    expect(unsafeRoute.route, '10.0.0.0/24');
+    expect(unsafeRoute.via, '100.100.1.1');
+
+    yaml = loadYaml('''
+    route: 3fff::1/24
+    via: 100.100.1.1
+    ''');
+    unsafeRoute = UnsafeRoute.fromYaml(yaml);
+    expect(unsafeRoute.route, '3fff::1/24');
+    expect(unsafeRoute.via, '100.100.1.1');
+
+    yaml = loadYaml('''
+    route: 100.100.1.1/24
+    via: 3fff::1
+    ''');
+    unsafeRoute = UnsafeRoute.fromYaml(yaml);
+    expect(unsafeRoute.route, '100.100.1.1/24');
+    expect(unsafeRoute.via, '3fff::1');
+
+    yaml = loadYaml('''
+    route: 2001:0DB8::1/24
+    via: 3fff::1
+    ''');
+    unsafeRoute = UnsafeRoute.fromYaml(yaml);
+    expect(unsafeRoute.route, '2001:0DB8::1/24');
+    expect(unsafeRoute.via, '3fff::1');
+
+    yaml = loadYaml('''
+    random: nope
+    ''');
+    expect(
+      () => UnsafeRoute.fromYaml(yaml),
+      throwsA(predicate((e) => e is ParseError && e.message == 'route was not a string')),
+    );
+
+    yaml = loadYaml('''
+    route: 123
+    ''');
+    expect(
+      () => UnsafeRoute.fromYaml(yaml),
+      throwsA(predicate((e) => e is ParseError && e.message == 'route was not a string')),
+    );
+
+    yaml = loadYaml('''
+    route: nope
+    ''');
+    expect(
+      () => UnsafeRoute.fromYaml(yaml),
+      throwsA(predicate((e) => e is ParseError && e.message == 'unable to parse CIDR from route: missing / separator')),
+    );
+
+    yaml = loadYaml('''
+    route: 10.1.1.1/24
+    ''');
+    expect(
+      () => UnsafeRoute.fromYaml(yaml),
+      throwsA(predicate((e) => e is ParseError && e.message == 'via was not a string')),
+    );
+
+    yaml = loadYaml('''
+    route: 10.1.1.1/24
+    via: 123
+    ''');
+    expect(
+      () => UnsafeRoute.fromYaml(yaml),
+      throwsA(predicate((e) => e is ParseError && e.message == 'via was not a string')),
+    );
+
+    yaml = loadYaml('''
+    route: 10.1.1.1/24
+    via: bad
+    ''');
+    expect(
+      () => UnsafeRoute.fromYaml(yaml),
+      throwsA(predicate((e) => e is ParseError && e.message == 'via was not a valid ip address')),
+    );
+  });
+}


### PR DESCRIPTION
Same story as #350 

Dart doesn't have a native exception chaining story so I opted to make `ParseError.message` settable so that I could add additional context when needed while maintaining the original stack trace.