### PR TITLE
Show both tag and Play Store version in About page

### DIFF
--- a/gen-artifacts.sh
+++ b/gen-artifacts.sh
@@ -37,6 +37,18 @@ cd ..
   # Get our current git sha
   git rev-parse --short HEAD | sed -e "s/\(.*\)/const gitSha = '\1';/"
 
+  # Get the git tag version
+  # If on an exact tag, gitIsTaggedRelease=true and gitTag is the tag name
+  # Otherwise, gitTag is just the closest tag (without commit count/sha suffix)
+  if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+    GIT_TAG="$(git describe --tags --exact-match HEAD)"
+    echo "const gitIsTaggedRelease = true;"
+  else
+    GIT_TAG="$(git describe --tags --always 2>/dev/null || echo 'unknown')"
+    echo "const gitIsTaggedRelease = false;"
+  fi
+  echo "const gitTag = '$GIT_TAG';"
+
   # Get the nebula version
   cd nebula
   NEBULA_VERSION="$(go list -m -f "{{.Version}}" github.com/slackhq/nebula | cut -f1 -d'-' | cut -c2-)"

--- a/lib/screens/about_screen.dart
+++ b/lib/screens/about_screen.dart
@@ -54,7 +54,12 @@ class AboutScreenState extends State<AboutScreen> {
               ConfigItem(
                 label: Text('App version'),
                 labelWidth: 150,
-                content: _buildText('${packageInfo!.version}-${packageInfo!.buildNumber} (sha: $gitSha)'),
+                content: _buildText(gitIsTaggedRelease ? '$gitTag ($gitSha)' : gitTag),
+              ),
+              ConfigItem(
+                label: Text('Store version'),
+                labelWidth: 150,
+                content: _buildText('${packageInfo!.version}-${packageInfo!.buildNumber}'),
               ),
               ConfigItem(
                 label: Text('Nebula version'),


### PR DESCRIPTION
The About page now shows two version lines:
- App version: git tag on tagged commits (with sha), or full git describe output on non-tagged commits
- Store version: Play Store versionName-versionCode

This makes it easy to identify which tagged release a build corresponds to, since the Play Store build number auto-increments independently of git tags.


| Untagged | Tagged |
|----------|---------|
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/8c658f6e-9242-4c14-99cf-878811532423" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/d9509270-a9a7-4af4-8f8f-bdc6f763f49f" /> |
