### PR TITLE
Add static_map.network config support for IPv6 DNS lookups

### DIFF
--- a/lib/models/site.dart
+++ b/lib/models/site.dart
@@ -284,6 +284,7 @@ class Site {
   int get mtu => _getConfigInt(['tun', 'mtu']) ?? 1300;
   String get cipher => _getConfigString(['cipher']) ?? 'aes';
   String get logVerbosity => _getConfigString(['logging', 'level']) ?? 'info';
+  String get staticMapNetwork => _getConfigString(['static_map', 'network']) ?? 'ip4';
   int get lhDuration => _getConfigInt(['lighthouse', 'interval']) ?? 0;
 
   List<UnsafeRoute> get unsafeRoutes {
@@ -327,6 +328,7 @@ class Site {
   set mtu(int value) => _setConfig(['tun', 'mtu'], value);
   set cipher(String value) => _setConfig(['cipher'], value);
   set logVerbosity(String value) => _setConfig(['logging', 'level'], value);
+  set staticMapNetwork(String value) => _setConfig(['static_map', 'network'], value);
   set lhDuration(int value) => _setConfig(['lighthouse', 'interval'], value);
 
   set unsafeRoutes(List<UnsafeRoute> routes) {

--- a/lib/screens/siteConfig/advanced_screen.dart
+++ b/lib/screens/siteConfig/advanced_screen.dart
@@ -12,12 +12,13 @@ import 'package:mobile_nebula/components/platform_text_form_field.dart';
 import 'package:mobile_nebula/models/site.dart';
 import 'package:mobile_nebula/models/unsafe_route.dart';
 import 'package:mobile_nebula/screens/siteConfig/cipher_screen.dart';
+import 'package:mobile_nebula/screens/siteConfig/dns_lookup_screen.dart';
 import 'package:mobile_nebula/screens/siteConfig/dns_resolvers_screen.dart';
+import 'package:mobile_nebula/screens/siteConfig/excluded_apps_screen.dart';
 import 'package:mobile_nebula/screens/siteConfig/log_verbosity_screen.dart';
 import 'package:mobile_nebula/screens/siteConfig/rendered_config_screen.dart';
 import 'package:mobile_nebula/services/utils.dart';
 
-import 'package:mobile_nebula/screens/siteConfig/excluded_apps_screen.dart';
 import 'unsafe_routes_screen.dart';
 
 //TODO: form validation (seconds and port)
@@ -34,6 +35,7 @@ class Advanced {
   int mtu;
   List<String> dnsResolvers;
   List<String> excludedApps;
+  String staticMapNetwork;
 
   Advanced({
     required this.lhDuration,
@@ -44,6 +46,7 @@ class Advanced {
     required this.mtu,
     required this.dnsResolvers,
     required this.excludedApps,
+    required this.staticMapNetwork,
   });
 }
 
@@ -72,6 +75,7 @@ class AdvancedScreenState extends State<AdvancedScreen> {
       mtu: widget.site.mtu,
       dnsResolvers: widget.site.dnsResolvers,
       excludedApps: widget.site.excludedApps,
+      staticMapNetwork: widget.site.staticMapNetwork,
     );
     super.initState();
   }
@@ -183,6 +187,25 @@ class AdvancedScreenState extends State<AdvancedScreen> {
                       onSave: (verbosity) {
                         setState(() {
                           settings.verbosity = verbosity;
+                          changed = true;
+                        });
+                      },
+                    );
+                  });
+                },
+              ),
+              ConfigPageItem(
+                disabled: widget.site.managed,
+                label: Text('DNS lookup mode'),
+                labelWidth: 150,
+                content: Text(settings.staticMapNetwork, textAlign: TextAlign.end),
+                onPressed: () {
+                  Utils.openPage(context, (context) {
+                    return DnsLookupScreen(
+                      staticMapNetwork: settings.staticMapNetwork,
+                      onSave: (staticMapNetwork) {
+                        setState(() {
+                          settings.staticMapNetwork = staticMapNetwork;
                           changed = true;
                         });
                       },

--- a/lib/screens/siteConfig/dns_lookup_screen.dart
+++ b/lib/screens/siteConfig/dns_lookup_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:mobile_nebula/components/config/config_checkbox_item.dart';
+import 'package:mobile_nebula/components/config/config_section.dart';
+import 'package:mobile_nebula/components/form_page.dart';
+
+class DnsLookupScreen extends StatefulWidget {
+  const DnsLookupScreen({super.key, required this.staticMapNetwork, required this.onSave});
+
+  final String staticMapNetwork;
+  final ValueChanged<String> onSave;
+
+  @override
+  DnsLookupScreenState createState() => DnsLookupScreenState();
+}
+
+class DnsLookupScreenState extends State<DnsLookupScreen> {
+  late String staticMapNetwork;
+  bool changed = false;
+
+  @override
+  void initState() {
+    staticMapNetwork = widget.staticMapNetwork;
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FormPage(
+      title: 'DNS Lookup Mode',
+      changed: changed,
+      onSave: () {
+        Navigator.pop(context);
+        widget.onSave(staticMapNetwork);
+      },
+      child: Column(
+        children: <Widget>[
+          ConfigSection(
+            children: [_buildEntry('ip4', 'IPv4 only'), _buildEntry('ip6', 'IPv6 only'), _buildEntry('ip', 'Both')],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEntry(String value, String label) {
+    return ConfigCheckboxItem(
+      label: Text(label),
+      labelWidth: 150,
+      checked: staticMapNetwork == value,
+      onChanged: () {
+        setState(() {
+          changed = true;
+          staticMapNetwork = value;
+        });
+      },
+    );
+  }
+}

--- a/lib/screens/siteConfig/site_config_screen.dart
+++ b/lib/screens/siteConfig/site_config_screen.dart
@@ -360,6 +360,7 @@ class SiteConfigScreenState extends State<SiteConfigScreen> {
                     site.dnsResolvers = settings.dnsResolvers;
                     site.mtu = settings.mtu;
                     site.excludedApps = settings.excludedApps;
+                    site.staticMapNetwork = settings.staticMapNetwork;
                   });
                 },
               );

--- a/test/models/site_test.dart
+++ b/test/models/site_test.dart
@@ -361,23 +361,14 @@ listen:
     });
 
     test('empty rawConfig string produces no error', () {
-      final parsed = Site.parseJson({
-        'name': 'empty config',
-        'id': 'empty-id',
-        'rawConfig': '',
-        'configVersion': 1,
-      });
+      final parsed = Site.parseJson({'name': 'empty config', 'id': 'empty-id', 'rawConfig': '', 'configVersion': 1});
       final errors = parsed['errors'] as List<String>;
       expect(errors, isEmpty);
       expect(parsed['rawConfig'], isEmpty);
     });
 
     test('missing rawConfig produces no error', () {
-      final parsed = Site.parseJson({
-        'name': 'no config',
-        'id': 'no-id',
-        'configVersion': 1,
-      });
+      final parsed = Site.parseJson({'name': 'no config', 'id': 'no-id', 'configVersion': 1});
       final errors = parsed['errors'] as List<String>;
       expect(errors, isEmpty);
     });


### PR DESCRIPTION
Adds a 'DNS lookup mode' setting to the Advanced config page that allows users to configure `static_map.network` to ip4 (default), ip6, or ip (both).

This enables users with IPv6-only lighthouse nodes to resolve AAAA records instead of being stuck with the ip4 default.

Closes #364

<img width="1280" height="2856" alt="image" src="https://github.com/user-attachments/assets/1e3e682d-243c-4e48-bab5-e8c60c1c10ce" />
