### PR TITLE
Fix dnsResolvers

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -357,7 +357,7 @@ class Site(context: Context, siteDir: File) {
             } ?: emptyList()
         } catch (_: Exception) { emptyList() }
 
-        // Parse dnsResolvers from rawConfig (stored under mobile_nebula.dns_resolvers by the UI)
+        // Parse dnsResolvers from rawConfig
         dnsResolvers = try {
             val mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? Map<*, *>
             val resolvers = mobileNebulaConfig?.get("dns_resolvers") as? List<*>

--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -93,7 +93,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
 
     if !_site.dnsResolvers.isEmpty {
       self.log.info("Assigning dns resolvers: \(_site.dnsResolvers, privacy: .public)")
-      tunnelNetworkSettings.dnsSettings = NEDNSSettings(servers: _site.dnsResolvers)
+      let dnsSettings = NEDNSSettings(servers: _site.dnsResolvers)
+      // An empty string in matchDomains means "match all domains", which tells iOS to
+      // actually route DNS queries through these servers. Without this, iOS ignores them.
+      dnsSettings.matchDomains = [""]
+      tunnelNetworkSettings.dnsSettings = dnsSettings
     }
 
     tunnelNetworkSettings.ipv4Settings = v4Settings

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -437,7 +437,7 @@ class Site: Encodable {
       unsafeRoutes = []
     }
 
-    // Parse dnsResolvers from rawConfig (stored under mobile_nebula.dns_resolvers by the UI)
+    // Parse dnsResolvers from rawConfig
     let mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? [String: Any]
     if let resolvers = mobileNebulaConfig?["dns_resolvers"] as? [String] {
       dnsResolvers = resolvers


### PR DESCRIPTION
2 problems, 1 in production.

- dnsResolvers on iOS needs an empty string matchDomain to actually work in split tunnel mode
- the config refactor missed the dnsResolvers move, only in dev builds.

Closes #372 