### PR TITLE
feat: support weighted multi-gateway unsafe routes

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -205,11 +205,17 @@ data class DNCredentials(
     }
 }
 
-// UnsafeRoute is used by the VPN service to configure routing
+// UnsafeRoute is used by the VPN service to configure routing.
+// `gateways` holds the nebula-ip + weight pairs; the VPN OS layer only uses `route`.
 data class UnsafeRoute(
     val route: String,
-    val via: String,
+    val gateways: List<UnsafeRouteGateway>,
     val mtu: Int?
+)
+
+data class UnsafeRouteGateway(
+    val gateway: String,
+    val weight: Int
 )
 
 /**
@@ -355,16 +361,26 @@ class Site(context: Context, siteDir: File) {
         // Parse mtu from rawConfig
         mtu = getConfigInt(rawConfigMap, listOf("tun", "mtu")) ?: 1300
 
-        // Parse unsafeRoutes from rawConfig
+        // Parse unsafeRoutes from rawConfig.
+        // `via` may be a legacy string (single gateway) or a list of {gateway, weight} maps.
         unsafeRoutes = try {
             val tun = rawConfigMap["tun"] as? Map<*, *>
             val routes = tun?.get("unsafe_routes") as? List<*>
             routes?.mapNotNull { r ->
                 val routeMap = r as? Map<*, *> ?: return@mapNotNull null
                 val route = routeMap["route"] as? String ?: return@mapNotNull null
-                val via = routeMap["via"] as? String ?: return@mapNotNull null
                 val routeMtu = (routeMap["mtu"] as? Number)?.toInt()
-                UnsafeRoute(route, via, routeMtu)
+                val gateways = when (val via = routeMap["via"]) {
+                    is String -> listOf(UnsafeRouteGateway(via, 1))
+                    is List<*> -> via.mapNotNull { item ->
+                        val gMap = item as? Map<*, *> ?: return@mapNotNull null
+                        val gw = gMap["gateway"] as? String ?: return@mapNotNull null
+                        val wt = (gMap["weight"] as? Number)?.toInt() ?: 1
+                        UnsafeRouteGateway(gw, wt)
+                    }
+                    else -> emptyList()
+                }
+                UnsafeRoute(route, gateways, routeMtu)
             } ?: emptyList()
         } catch (_: Exception) { emptyList() }
 

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -144,15 +144,26 @@ let statusString: [NEVPNStatus: String] = [
   NEVPNStatus.disconnecting: "Disconnecting...",
 ]
 
-// UnsafeRoute is used by the VPN service to configure routing
+// UnsafeRoute is used by the VPN service to configure routing.
+// `gateways` holds the nebula-ip + weight pairs; the VPN OS layer only uses `route`.
+class UnsafeRouteGateway: Codable {
+  var gateway: String
+  var weight: Int
+
+  init(gateway: String, weight: Int = 1) {
+    self.gateway = gateway
+    self.weight = weight
+  }
+}
+
 class UnsafeRoute: Codable {
   var route: String
-  var via: String
+  var gateways: [UnsafeRouteGateway]
   var mtu: Int?
 
-  init(route: String, via: String, mtu: Int? = nil) {
+  init(route: String, gateways: [UnsafeRouteGateway], mtu: Int? = nil) {
     self.route = route
-    self.via = via
+    self.gateways = gateways
     self.mtu = mtu
   }
 }
@@ -434,15 +445,25 @@ class Site: Encodable {
     let tun = rawConfigMap["tun"] as? [String: Any]
     mtu = tun?["mtu"] as? Int ?? 1300
 
-    // Parse unsafeRoutes from rawConfig
+    // Parse unsafeRoutes from rawConfig.
+    // `via` may be a legacy string (single gateway) or a list of {gateway, weight} dicts.
     if let routes = tun?["unsafe_routes"] as? [[String: Any]] {
       unsafeRoutes = routes.compactMap { routeMap in
-        guard let route = routeMap["route"] as? String,
-          let via = routeMap["via"] as? String
-        else {
-          return nil
+        guard let route = routeMap["route"] as? String else { return nil }
+        let routeMtu = routeMap["mtu"] as? Int
+        let gateways: [UnsafeRouteGateway]
+        if let viaStr = routeMap["via"] as? String {
+          gateways = [UnsafeRouteGateway(gateway: viaStr)]
+        } else if let viaList = routeMap["via"] as? [[String: Any]] {
+          gateways = viaList.compactMap { item in
+            guard let gw = item["gateway"] as? String else { return nil }
+            let wt = item["weight"] as? Int ?? 1
+            return UnsafeRouteGateway(gateway: gw, weight: wt)
+          }
+        } else {
+          gateways = []
         }
-        return UnsafeRoute(route: route, via: via, mtu: routeMap["mtu"] as? Int)
+        return UnsafeRoute(route: route, gateways: gateways, mtu: routeMtu)
       }
     } else {
       unsafeRoutes = []

--- a/lib/models/unsafe_route.dart
+++ b/lib/models/unsafe_route.dart
@@ -4,11 +4,24 @@ import 'package:yaml/yaml.dart';
 
 import 'cidr.dart';
 
+class Gateway {
+  String gateway;
+  int weight;
+
+  Gateway({required this.gateway, this.weight = 1});
+
+  factory Gateway.fromJson(Map<String, dynamic> json) {
+    return Gateway(gateway: json['gateway'] as String? ?? '', weight: (json['weight'] as num?)?.toInt() ?? 1);
+  }
+
+  Map<String, dynamic> toJson() => {'gateway': gateway, 'weight': weight};
+}
+
 class UnsafeRoute {
   String? route;
-  String? via;
+  List<Gateway> via;
 
-  UnsafeRoute({this.route, this.via});
+  UnsafeRoute({this.route, List<Gateway>? via}) : via = via ?? [];
 
   factory UnsafeRoute.fromYaml(dynamic yaml) {
     if (yaml is! YamlMap) {
@@ -27,13 +40,36 @@ class UnsafeRoute {
       throw ParseError('route was not a string');
     }
 
-    if (yaml.containsKey('via') && yaml['via'] is String) {
-      final yamlVia = yaml['via'] as String;
-      var (valid, _) = ipValidator(yamlVia);
+    final viaValue = yaml['via'];
+    if (viaValue is String) {
+      // Legacy single-gateway string format
+      var (valid, _) = ipValidator(viaValue);
       if (!valid) {
         throw ParseError('via was not a valid ip address');
       }
-      unsafeRoute.via = yamlVia;
+      unsafeRoute.via = [Gateway(gateway: viaValue)];
+    } else if (viaValue is YamlList) {
+      // New multi-gateway list format: [{gateway: ip, weight: n}, ...]
+      final gateways = <Gateway>[];
+      for (final item in viaValue) {
+        if (item is! YamlMap) {
+          throw ParseError('via list item was not a map');
+        }
+        final gatewayStr = item['gateway'];
+        if (gatewayStr is! String) {
+          throw ParseError('gateway was not a string');
+        }
+        var (valid, _) = ipValidator(gatewayStr);
+        if (!valid) {
+          throw ParseError('gateway was not a valid ip address');
+        }
+        final weight = item['weight'];
+        gateways.add(Gateway(gateway: gatewayStr, weight: weight is int ? weight : 1));
+      }
+      if (gateways.isEmpty) {
+        throw ParseError('via list was empty');
+      }
+      unsafeRoute.via = gateways;
     } else {
       throw ParseError('via was not a string');
     }
@@ -42,10 +78,20 @@ class UnsafeRoute {
   }
 
   factory UnsafeRoute.fromJson(Map<String, dynamic> json) {
-    return UnsafeRoute(route: json['route'], via: json['via']);
+    final viaRaw = json['via'];
+    List<Gateway> gateways;
+    if (viaRaw is String) {
+      // Legacy format: single gateway stored as plain string
+      gateways = [Gateway(gateway: viaRaw)];
+    } else if (viaRaw is List) {
+      gateways = viaRaw.map((e) => Gateway.fromJson(Map<String, dynamic>.from(e as Map))).toList();
+    } else {
+      gateways = [];
+    }
+    return UnsafeRoute(route: json['route'] as String?, via: gateways);
   }
 
   Map<String, dynamic> toJson() {
-    return {'route': route, 'via': via};
+    return {'route': route, 'via': via.map((g) => g.toJson()).toList()};
   }
 }

--- a/lib/screens/siteConfig/unsafe_route_screen.dart
+++ b/lib/screens/siteConfig/unsafe_route_screen.dart
@@ -53,6 +53,7 @@ class UnsafeRouteScreenState extends State<UnsafeRouteScreen> {
 
   @override
   void dispose() {
+    routeFocus.dispose();
     for (final c in _gatewayControllers) {
       c.dispose();
     }
@@ -153,7 +154,6 @@ class UnsafeRouteScreenState extends State<UnsafeRouteScreen> {
                     if (!valid) return 'Invalid IP';
                     return null;
                   },
-                  onChanged: (_) => setState(() => changed = true),
                 ),
               ),
               if (canRemove)
@@ -188,7 +188,6 @@ class UnsafeRouteScreenState extends State<UnsafeRouteScreen> {
                     if (n == null || n < 1) return '≥1';
                     return null;
                   },
-                  onChanged: (_) => setState(() => changed = true),
                 ),
               ),
             ],

--- a/lib/screens/siteConfig/unsafe_route_screen.dart
+++ b/lib/screens/siteConfig/unsafe_route_screen.dart
@@ -1,13 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:mobile_nebula/components/danger_button.dart';
 import 'package:mobile_nebula/components/cidr_form_field.dart';
+import 'package:mobile_nebula/components/config/config_button_item.dart';
 import 'package:mobile_nebula/components/config/config_item.dart';
 import 'package:mobile_nebula/components/config/config_section.dart';
 import 'package:mobile_nebula/components/form_page.dart';
-import 'package:mobile_nebula/components/ip_form_field.dart';
 import 'package:mobile_nebula/models/cidr.dart';
 import 'package:mobile_nebula/models/unsafe_route.dart';
 import 'package:mobile_nebula/services/utils.dart';
+import 'package:mobile_nebula/validators/ip_validator.dart';
+
+class _GatewayControllers {
+  final TextEditingController ip;
+  final TextEditingController weight;
+
+  _GatewayControllers({String gateway = '', int weight = 1})
+    : ip = TextEditingController(text: gateway),
+      weight = TextEditingController(text: weight.toString());
+
+  void dispose() {
+    ip.dispose();
+    weight.dispose();
+  }
+}
 
 class UnsafeRouteScreen extends StatefulWidget {
   const UnsafeRouteScreen({super.key, required this.route, required this.onSave, this.onDelete});
@@ -23,15 +39,24 @@ class UnsafeRouteScreen extends StatefulWidget {
 class UnsafeRouteScreenState extends State<UnsafeRouteScreen> {
   late UnsafeRoute route;
   bool changed = false;
+  late List<_GatewayControllers> _gatewayControllers;
 
   FocusNode routeFocus = FocusNode();
-  FocusNode viaFocus = FocusNode();
-  FocusNode mtuFocus = FocusNode();
 
   @override
   void initState() {
-    route = widget.route;
+    route = UnsafeRoute(route: widget.route.route, via: []);
+    final initial = widget.route.via.isNotEmpty ? widget.route.via : [Gateway(gateway: '', weight: 1)];
+    _gatewayControllers = initial.map((g) => _GatewayControllers(gateway: g.gateway, weight: g.weight)).toList();
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _gatewayControllers) {
+      c.dispose();
+    }
+    super.dispose();
   }
 
   @override
@@ -52,45 +77,26 @@ class UnsafeRouteScreenState extends State<UnsafeRouteScreen> {
                   initialValue: routeCIDR,
                   textInputAction: TextInputAction.next,
                   focusNode: routeFocus,
-                  nextFocusNode: viaFocus,
                   onSaved: (v) {
                     route.route = v.toString();
                   },
                 ),
               ),
-              ConfigItem(
-                label: Text('Via'),
-                content: IPFormField(
-                  initialValue: route.via ?? '',
-                  ipOnly: true,
-                  help: 'nebula ip',
-                  textAlign: TextAlign.end,
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  textInputAction: TextInputAction.next,
-                  focusNode: viaFocus,
-                  nextFocusNode: mtuFocus,
-                  onSaved: (v) {
-                    if (v != null) {
-                      route.via = v;
-                    }
-                  },
-                ),
+            ],
+          ),
+          ConfigSection(
+            label: 'Gateways',
+            children: [
+              ..._buildGatewayRows(),
+              ConfigButtonItem(
+                content: Text('Add Gateway'),
+                onPressed: () {
+                  setState(() {
+                    changed = true;
+                    _gatewayControllers.add(_GatewayControllers());
+                  });
+                },
               ),
-              //TODO: Android doesn't appear to support route based MTU, figure this out
-              //            ConfigItem(
-              //                label: Text('MTU'),
-              //                content: AppTextFormField(
-              //                    placeholder: "",
-              //                    validator: mtuValidator(false),
-              //                    keyboardType: TextInputType.number,
-              //                    inputFormatters: [WhitelistingTextInputFormatter.digitsOnly],
-              //                    initialValue: route?.mtu.toString(),
-              //                    textAlign: TextAlign.end,
-              //                    textInputAction: TextInputAction.done,
-              //                    focusNode: mtuFocus,
-              //                    onSaved: (v) {
-              //                      route.mtu = int.tryParse(v);
-              //                    })),
             ],
           ),
           widget.onDelete != null
@@ -113,8 +119,90 @@ class UnsafeRouteScreenState extends State<UnsafeRouteScreen> {
     );
   }
 
+  List<Widget> _buildGatewayRows() {
+    final rows = <Widget>[];
+    for (int i = 0; i < _gatewayControllers.length; i++) {
+      rows.add(_buildGatewayRow(i));
+    }
+    return rows;
+  }
+
+  Widget _buildGatewayRow(int index) {
+    final ctrl = _gatewayControllers[index];
+    final canRemove = _gatewayControllers.length > 1;
+
+    return ConfigItem(
+      label: Text('Gateway ${index + 1}'),
+      labelWidth: 110,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      padding: EdgeInsets.symmetric(vertical: 8, horizontal: 15),
+      content: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextFormField(
+                  controller: ctrl.ip,
+                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                  textAlign: TextAlign.end,
+                  decoration: InputDecoration(hintText: 'nebula ip', isDense: true, border: InputBorder.none),
+                  validator: (v) {
+                    if (v == null || v.isEmpty) return 'Required';
+                    var (valid, _) = ipValidator(v);
+                    if (!valid) return 'Invalid IP';
+                    return null;
+                  },
+                  onChanged: (_) => setState(() => changed = true),
+                ),
+              ),
+              if (canRemove)
+                GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      changed = true;
+                      _gatewayControllers.removeAt(index).dispose();
+                    });
+                  },
+                  child: Padding(
+                    padding: EdgeInsets.only(left: 8),
+                    child: Icon(Icons.remove_circle_outline, color: Colors.red, size: 20),
+                  ),
+                ),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Text('Weight: ', style: TextStyle(fontSize: 12, color: Colors.grey)),
+              SizedBox(
+                width: 48,
+                child: TextFormField(
+                  controller: ctrl.weight,
+                  keyboardType: TextInputType.number,
+                  textAlign: TextAlign.center,
+                  decoration: InputDecoration(isDense: true, border: InputBorder.none),
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  validator: (v) {
+                    final n = int.tryParse(v ?? '');
+                    if (n == null || n < 1) return '≥1';
+                    return null;
+                  },
+                  onChanged: (_) => setState(() => changed = true),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   void _onSave() {
     Navigator.pop(context);
+    route.via = _gatewayControllers
+        .map((c) => Gateway(gateway: c.ip.text, weight: int.tryParse(c.weight.text) ?? 1))
+        .toList();
     widget.onSave(route);
   }
 }

--- a/lib/screens/siteConfig/unsafe_routes_screen.dart
+++ b/lib/screens/siteConfig/unsafe_routes_screen.dart
@@ -48,6 +48,12 @@ class UnsafeRoutesScreenState extends State<UnsafeRoutesScreen> {
     }
   }
 
+  String _viaLabel(UnsafeRoute route) {
+    if (route.via.isEmpty) return 'via —';
+    if (route.via.length == 1) return 'via ${route.via.first.gateway}';
+    return 'via ${route.via.length} gateways';
+  }
+
   List<Widget> _buildRoutes() {
     final double ipWidth = Utils.textSize("000.000.000.000/00", Theme.of(context).textTheme.labelLarge!).width;
     List<Widget> items = [];
@@ -57,7 +63,7 @@ class UnsafeRoutesScreenState extends State<UnsafeRoutesScreen> {
           disabled: widget.onSave == null,
           label: Text(route.route ?? ''),
           labelWidth: ipWidth,
-          content: Text('via ${route.via}', textAlign: TextAlign.end),
+          content: Text(_viaLabel(route), textAlign: TextAlign.end),
           onPressed: () {
             Utils.openPage(context, (context) {
               return UnsafeRouteScreen(

--- a/test/models/site_test.dart
+++ b/test/models/site_test.dart
@@ -92,7 +92,9 @@ tun:
         );
         expect(site.unsafeRoutes.length, 1);
         expect(site.unsafeRoutes[0].route, '10.0.0.0/24');
-        expect(site.unsafeRoutes[0].via, '192.168.1.1');
+        expect(site.unsafeRoutes[0].via.length, 1);
+        expect(site.unsafeRoutes[0].via[0].gateway, '192.168.1.1');
+        expect(site.unsafeRoutes[0].via[0].weight, 1);
         expect(site.errors, isEmpty);
       });
 

--- a/test/models/unsafe_route_test.dart
+++ b/test/models/unsafe_route_test.dart
@@ -4,87 +4,255 @@ import 'package:mobile_nebula/models/unsafe_route.dart';
 import 'package:yaml/yaml.dart';
 
 void main() {
-  test('UnsafeRoute.fromYaml', () {
-    var yaml = loadYaml('''
-    route: 10.0.0.0/24
-    via: 100.100.1.1
-    ''');
-    var unsafeRoute = UnsafeRoute.fromYaml(yaml);
-    expect(unsafeRoute.route, '10.0.0.0/24');
-    expect(unsafeRoute.via, '100.100.1.1');
+  group('UnsafeRoute.fromYaml', () {
+    test('single gateway (legacy string via)', () {
+      var yaml = loadYaml('''
+      route: 10.0.0.0/24
+      via: 100.100.1.1
+      ''');
+      var unsafeRoute = UnsafeRoute.fromYaml(yaml);
+      expect(unsafeRoute.route, '10.0.0.0/24');
+      expect(unsafeRoute.via.length, 1);
+      expect(unsafeRoute.via.first.gateway, '100.100.1.1');
+      expect(unsafeRoute.via.first.weight, 1);
+    });
 
-    yaml = loadYaml('''
-    route: 3fff::1/24
-    via: 100.100.1.1
-    ''');
-    unsafeRoute = UnsafeRoute.fromYaml(yaml);
-    expect(unsafeRoute.route, '3fff::1/24');
-    expect(unsafeRoute.via, '100.100.1.1');
+    test('single gateway IPv6 via', () {
+      var yaml = loadYaml('''
+      route: 3fff::1/24
+      via: 100.100.1.1
+      ''');
+      var unsafeRoute = UnsafeRoute.fromYaml(yaml);
+      expect(unsafeRoute.route, '3fff::1/24');
+      expect(unsafeRoute.via.first.gateway, '100.100.1.1');
+    });
 
-    yaml = loadYaml('''
-    route: 100.100.1.1/24
-    via: 3fff::1
-    ''');
-    unsafeRoute = UnsafeRoute.fromYaml(yaml);
-    expect(unsafeRoute.route, '100.100.1.1/24');
-    expect(unsafeRoute.via, '3fff::1');
+    test('single gateway IPv4 route IPv6 via', () {
+      var yaml = loadYaml('''
+      route: 100.100.1.1/24
+      via: 3fff::1
+      ''');
+      var unsafeRoute = UnsafeRoute.fromYaml(yaml);
+      expect(unsafeRoute.route, '100.100.1.1/24');
+      expect(unsafeRoute.via.first.gateway, '3fff::1');
+    });
 
-    yaml = loadYaml('''
-    route: 2001:0DB8::1/24
-    via: 3fff::1
-    ''');
-    unsafeRoute = UnsafeRoute.fromYaml(yaml);
-    expect(unsafeRoute.route, '2001:0DB8::1/24');
-    expect(unsafeRoute.via, '3fff::1');
+    test('single gateway IPv6 both', () {
+      var yaml = loadYaml('''
+      route: 2001:0DB8::1/24
+      via: 3fff::1
+      ''');
+      var unsafeRoute = UnsafeRoute.fromYaml(yaml);
+      expect(unsafeRoute.route, '2001:0DB8::1/24');
+      expect(unsafeRoute.via.first.gateway, '3fff::1');
+    });
 
-    yaml = loadYaml('''
-    random: nope
-    ''');
-    expect(
-      () => UnsafeRoute.fromYaml(yaml),
-      throwsA(predicate((e) => e is ParseError && e.message == 'route was not a string')),
-    );
+    test('multi-gateway list with weights', () {
+      var yaml = loadYaml('''
+      route: 192.168.87.0/24
+      via:
+        - gateway: 10.0.0.1
+          weight: 10
+        - gateway: 10.0.0.2
+          weight: 5
+      ''');
+      var unsafeRoute = UnsafeRoute.fromYaml(yaml);
+      expect(unsafeRoute.route, '192.168.87.0/24');
+      expect(unsafeRoute.via.length, 2);
+      expect(unsafeRoute.via[0].gateway, '10.0.0.1');
+      expect(unsafeRoute.via[0].weight, 10);
+      expect(unsafeRoute.via[1].gateway, '10.0.0.2');
+      expect(unsafeRoute.via[1].weight, 5);
+    });
 
-    yaml = loadYaml('''
-    route: 123
-    ''');
-    expect(
-      () => UnsafeRoute.fromYaml(yaml),
-      throwsA(predicate((e) => e is ParseError && e.message == 'route was not a string')),
-    );
+    test('multi-gateway list without weight defaults to 1', () {
+      var yaml = loadYaml('''
+      route: 10.0.0.0/24
+      via:
+        - gateway: 10.1.0.1
+        - gateway: 10.1.0.2
+      ''');
+      var unsafeRoute = UnsafeRoute.fromYaml(yaml);
+      expect(unsafeRoute.via.length, 2);
+      expect(unsafeRoute.via[0].weight, 1);
+      expect(unsafeRoute.via[1].weight, 1);
+    });
 
-    yaml = loadYaml('''
-    route: nope
-    ''');
-    expect(
-      () => UnsafeRoute.fromYaml(yaml),
-      throwsA(predicate((e) => e is ParseError && e.message == 'unable to parse CIDR from route: missing / separator')),
-    );
+    test('missing route', () {
+      var yaml = loadYaml('''
+      random: nope
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'route was not a string')),
+      );
+    });
 
-    yaml = loadYaml('''
-    route: 10.1.1.1/24
-    ''');
-    expect(
-      () => UnsafeRoute.fromYaml(yaml),
-      throwsA(predicate((e) => e is ParseError && e.message == 'via was not a string')),
-    );
+    test('route is not a string', () {
+      var yaml = loadYaml('''
+      route: 123
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'route was not a string')),
+      );
+    });
 
-    yaml = loadYaml('''
-    route: 10.1.1.1/24
-    via: 123
-    ''');
-    expect(
-      () => UnsafeRoute.fromYaml(yaml),
-      throwsA(predicate((e) => e is ParseError && e.message == 'via was not a string')),
-    );
+    test('invalid CIDR route', () {
+      var yaml = loadYaml('''
+      route: nope
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(
+          predicate((e) => e is ParseError && e.message == 'unable to parse CIDR from route: missing / separator'),
+        ),
+      );
+    });
 
-    yaml = loadYaml('''
-    route: 10.1.1.1/24
-    via: bad
-    ''');
-    expect(
-      () => UnsafeRoute.fromYaml(yaml),
-      throwsA(predicate((e) => e is ParseError && e.message == 'via was not a valid ip address')),
-    );
+    test('missing via', () {
+      var yaml = loadYaml('''
+      route: 10.1.1.1/24
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'via was not a string')),
+      );
+    });
+
+    test('via is a number (not string)', () {
+      var yaml = loadYaml('''
+      route: 10.1.1.1/24
+      via: 123
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'via was not a string')),
+      );
+    });
+
+    test('via is an invalid ip address', () {
+      var yaml = loadYaml('''
+      route: 10.1.1.1/24
+      via: bad
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'via was not a valid ip address')),
+      );
+    });
+
+    test('gateway list item is not a map', () {
+      var yaml = loadYaml('''
+      route: 10.1.1.1/24
+      via:
+        - 10.0.0.1
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'via list item was not a map')),
+      );
+    });
+
+    test('gateway list item missing gateway key', () {
+      var yaml = loadYaml('''
+      route: 10.1.1.1/24
+      via:
+        - weight: 5
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'gateway was not a string')),
+      );
+    });
+
+    test('gateway list item has invalid ip', () {
+      var yaml = loadYaml('''
+      route: 10.1.1.1/24
+      via:
+        - gateway: notanip
+          weight: 1
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'gateway was not a valid ip address')),
+      );
+    });
+
+    test('empty via list', () {
+      var yaml = loadYaml('''
+      route: 10.1.1.1/24
+      via: []
+      ''');
+      expect(
+        () => UnsafeRoute.fromYaml(yaml),
+        throwsA(predicate((e) => e is ParseError && e.message == 'via list was empty')),
+      );
+    });
+  });
+
+  group('UnsafeRoute.fromJson', () {
+    test('legacy string via is migrated to single-gateway list', () {
+      final route = UnsafeRoute.fromJson({'route': '10.0.0.0/24', 'via': '10.0.0.1'});
+      expect(route.via.length, 1);
+      expect(route.via.first.gateway, '10.0.0.1');
+      expect(route.via.first.weight, 1);
+    });
+
+    test('new list via is parsed correctly', () {
+      final route = UnsafeRoute.fromJson({
+        'route': '10.0.0.0/24',
+        'via': [
+          {'gateway': '10.0.0.1', 'weight': 10},
+          {'gateway': '10.0.0.2', 'weight': 5},
+        ],
+      });
+      expect(route.via.length, 2);
+      expect(route.via[0].gateway, '10.0.0.1');
+      expect(route.via[0].weight, 10);
+      expect(route.via[1].gateway, '10.0.0.2');
+      expect(route.via[1].weight, 5);
+    });
+
+    test('null via becomes empty list', () {
+      final route = UnsafeRoute.fromJson({'route': '10.0.0.0/24'});
+      expect(route.via, isEmpty);
+    });
+  });
+
+  group('UnsafeRoute.toJson round-trip', () {
+    test('multi-gateway toJson produces list format', () {
+      final route = UnsafeRoute(
+        route: '192.168.87.0/24',
+        via: [
+          Gateway(gateway: '10.0.0.1', weight: 10),
+          Gateway(gateway: '10.0.0.2', weight: 5),
+        ],
+      );
+      final json = route.toJson();
+      expect(json['route'], '192.168.87.0/24');
+      expect(json['via'], isA<List>());
+      final viaList = json['via'] as List;
+      expect(viaList.length, 2);
+      expect(viaList[0], {'gateway': '10.0.0.1', 'weight': 10});
+      expect(viaList[1], {'gateway': '10.0.0.2', 'weight': 5});
+    });
+
+    test('toJson -> fromJson round-trip preserves data', () {
+      final original = UnsafeRoute(
+        route: '10.0.0.0/24',
+        via: [
+          Gateway(gateway: '10.1.0.1', weight: 3),
+          Gateway(gateway: '10.1.0.2', weight: 7),
+        ],
+      );
+      final restored = UnsafeRoute.fromJson(original.toJson());
+      expect(restored.route, original.route);
+      expect(restored.via.length, 2);
+      expect(restored.via[0].gateway, '10.1.0.1');
+      expect(restored.via[0].weight, 3);
+      expect(restored.via[1].gateway, '10.1.0.2');
+      expect(restored.via[1].weight, 7);
+    });
   });
 }


### PR DESCRIPTION
## Summary

The Go nebula library already supports weighted ECMP across multiple
gateways per unsafe route, but the mobile client only exposed a single
`via` string. This PR wires that capability through all four layers of
the mobile stack.

**Config format now supported:**
```yaml
unsafe_routes:
  - route: 192.168.87.0/24
    via:
      - gateway: 10.0.0.1
        weight: 10
      - gateway: 10.0.0.2
        weight: 5
```

##  Changes
- `lib/models/unsafe_route.dart` - add `Gateway(gateway, weight)` model;
`UnsafeRoute.via` is now `List<Gateway>`; `fromYaml` handles both the legacy
single-string format and the new list format; fromJson handles legacy string
for backward compatibility with existing stored configs
- `lib/screens/siteConfig/unsafe_route_screen.dart` - UI supports
adding/removing multiple gateways per route with per-entry IP and weight
fields
- `lib/screens/siteConfig/unsafe_routes_screen.dart` - list view shows
`via 10.0.0.1` for single gateway, via N gateways for multiple
`android/.../Sites.kt` - add `UnsafeRouteGateway data class`; parsing
handles both legacy string via and new [{gateway, weight}] list format
- `ios/NebulaNetworkExtension/Site.swift` - same as above for iOS
- `test/models/unsafe_route_test.dart` - full coverage of multi-gateway
YAML parsing, legacy compat, and toJson/fromJson round-trip
- `test/models/site_test.dart `- update assertion to match new `List<Gateway>` shape

## Backward compatibility
- Existing configs with via: "10.0.0.1" (plain string) continue to work
in both YAML import and stored JSON — they are transparently migrated to
a single-entry gateway list.