### PR TITLE
Truncate long names instead of running off screen

### DIFF
--- a/lib/components/pill_chip.dart
+++ b/lib/components/pill_chip.dart
@@ -98,10 +98,20 @@ enum PillChipBorder {
 /// Themed via [PillChipThemeData] (as a [ThemeExtension] or via
 /// [PillChipTheme] in the widget tree). Falls back to [ColorScheme] defaults.
 class PillChip extends StatelessWidget {
-  const PillChip({super.key, required this.label, this.trailingIcon, this.onTap, this.border = PillChipBorder.none});
+  const PillChip({
+    super.key,
+    required this.label,
+    this.trailingIcon,
+    this.onTap,
+    this.border = PillChipBorder.none,
+    this.maxLines = 3,
+  });
 
   /// The text label displayed inside the chip.
   final String label;
+
+  /// Maximum number of lines the label wraps to before it ellipsizes.
+  final int maxLines;
 
   /// Optional trailing icon (e.g. a close/remove icon).
   final IconData? trailingIcon;
@@ -134,7 +144,9 @@ class PillChip extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Flexible(
-            child: Text(label, style: resolvedTextStyle, overflow: TextOverflow.ellipsis),
+            // A label wider than the chip's constraints wraps rather than running past the edge. Flutter breaks
+            // mid-token when there is no whitespace or hyphen to break on, so unseparated names still fit.
+            child: Text(label, style: resolvedTextStyle, maxLines: maxLines, overflow: TextOverflow.ellipsis),
           ),
           if (trailingIcon != null) ...[const SizedBox(width: 4), Icon(trailingIcon, color: theme.textColor, size: 16)],
         ],

--- a/lib/components/pill_chip.dart
+++ b/lib/components/pill_chip.dart
@@ -133,7 +133,9 @@ class PillChip extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(label, style: resolvedTextStyle),
+          Flexible(
+            child: Text(label, style: resolvedTextStyle, overflow: TextOverflow.ellipsis),
+          ),
           if (trailingIcon != null) ...[const SizedBox(width: 4), Icon(trailingIcon, color: theme.textColor, size: 16)],
         ],
       ),

--- a/lib/screens/site_tunnels_screen.dart
+++ b/lib/screens/site_tunnels_screen.dart
@@ -75,7 +75,7 @@ class SiteTunnelsScreenState extends State<SiteTunnelsScreen> {
           child: Row(
             children: <Widget>[
               Padding(padding: EdgeInsets.only(right: 10), child: icon),
-              Text(hostInfo.cert?.name ?? hostInfo.vpnAddrs[0]),
+              Expanded(child: Text(hostInfo.cert?.name ?? hostInfo.vpnAddrs[0], overflow: TextOverflow.ellipsis)),
             ],
           ),
         ),


### PR DESCRIPTION
Long names could run past the right edge of the screen. Two places lay a
name out in a `Row` with no width constraint, so the text overlapped the
row's chevron and continued off screen:

- **Active/Pending Tunnels** - the cert name (`site_tunnels_screen.dart`)
- **Firewall Rule** - a group name chip (`pill_chip.dart`)

Both now ellipsize at the edge.

## Screenshots

360dp wide, the common Android width. The red bar and hazard stripes are
Flutter's debug overflow indicator.

### Active Tunnels

| before | after |
| --- | --- |
| <img width="1080" height="900" alt="tunnels-before" src="https://github.com/user-attachments/assets/3be0afee-325b-4918-b34e-9ccdeb18bd44" /> | <img width="1080" height="900" alt="tunnels-after" src="https://github.com/user-attachments/assets/aeb9c1c6-9134-46f1-bab5-4671b69ddec3" /> |

### Firewall Rule groups

| before | after |
| --- | --- |
| <img width="1080" height="900" alt="image" src="https://github.com/user-attachments/assets/de06026c-9ba4-4375-8836-46f784573fbb" /> | <img width="1080" height="900" alt="image" src="https://github.com/user-attachments/assets/bd192e36-840e-4906-a6ed-33a7a2408828" /> |
