### PR TITLE
Allow local dns resolver config for managed sites

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/ConfigMigrator.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/ConfigMigrator.kt
@@ -5,35 +5,32 @@ import java.io.File
 
 object ConfigMigrator {
     /**
-     * Migrates a site's config to the latest version if needed.
-     * Writes the migrated config back to disk and returns the updated JSON.
+     * Brings a site config up to date and writes it back to disk if anything changed.
+     *
+     * The migrations themselves all live in Go. This knows nothing about individual versions, it
+     * only supplies the private key that Go can't reach and handles the file, so adding a
+     * migration should not need a change here.
      */
     fun migrate(context: Context, siteDir: File, configJson: String): String {
-        val configMap: Map<String, Any?> =
-            com.google.gson.Gson().fromJson(configJson, object : com.google.gson.reflect.TypeToken<Map<String, Any?>>() {}.type)
-        var version = (configMap["configVersion"] as? Number)?.toInt() ?: 0
-        var result = configJson
-
-        if (version < 1) {
-            result = migrateToV1(context, siteDir, result)
-            version = 1
+        // Only the legacy format needs the key, so don't pay to decrypt it on every site load
+        val key = if (mobileNebula.MobileNebula.migrationNeedsKey(configJson)) {
+            try {
+                val f = EncFile(context).openRead(siteDir.resolve("key"))
+                val k = f.readText()
+                f.close()
+                k
+            } catch (_: Exception) { "" }
+        } else {
+            ""
         }
 
-        // Future migrations go here
-
-        return result
-    }
-
-    /** Migrates from v0 (old decomposed format) to v1 (rawConfig format). */
-    private fun migrateToV1(context: Context, siteDir: File, configJson: String): String {
-        val key = try {
-            val f = EncFile(context).openRead(siteDir.resolve("key"))
-            val k = f.readText()
-            f.close()
-            k
-        } catch (_: Exception) { "" }
-
         val migrated = mobileNebula.MobileNebula.migrateConfig(configJson, key)
+
+        // Go hands back the input verbatim when there is nothing to do
+        if (migrated == configJson) {
+            return configJson
+        }
+
         siteDir.resolve("config.json").writeText(migrated)
         return migrated
     }

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.work.*
 import com.google.gson.Gson
+import com.google.gson.JsonObject
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
@@ -275,7 +276,9 @@ class MainActivity: FlutterActivity() {
         val siteDir: File
         try {
             val json = apiClient!!.enroll(code)
-            siteDir = saveSite(context, json)
+            // Re-enrolling an existing host keeps its client side settings
+            val id = Gson().fromJson(json, JsonObject::class.java)?.get("id")?.asString
+            siteDir = saveSite(context, json, existingSite = id?.let { sites?.getSite(it)?.site })
         } catch (err: Exception) {
             return result.error("unhandled_error", err.message, null)
         }
@@ -306,9 +309,14 @@ class MainActivity: FlutterActivity() {
 
     private fun saveSite(call: MethodCall, result: MethodChannel.Result) {
         val json = call.arguments as String
+        val gson = Gson()
+        val map: Map<String, Any?> = gson.fromJson(json, object : com.google.gson.reflect.TypeToken<Map<String, Any?>>() {}.type)
+        val alwaysOn = map["alwaysOn"] as? Boolean ?: false
+        val id = map["id"] as? String
+
         val siteDir: File
         try {
-            siteDir = saveSite(context, json)
+            siteDir = saveSite(context, json, existingSite = id?.let { sites?.getSite(it)?.site })
         } catch (err: Exception) {
             //TODO: is toString the best or .message?
             return result.error("failure", err.toString(), null)
@@ -319,11 +327,6 @@ class MainActivity: FlutterActivity() {
         }
 
         // Check if we need to start/restart for always-on
-        val gson = Gson()
-        val map: Map<String, Any?> = gson.fromJson(json, object : com.google.gson.reflect.TypeToken<Map<String, Any?>>() {}.type)
-        val alwaysOn = map["alwaysOn"] as? Boolean ?: false
-        val id = map["id"] as? String
-
         if (alwaysOn && id != null) {
             if (activeSiteId != null && activeSiteId != id) {
                 stopSite { sites?.getSite(id)?.let { startSiteDirectly(it) } }

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -193,7 +193,7 @@ class NebulaVpnService : VpnService() {
         }
 
         var hasDnsResolvers = false
-        site!!.dnsResolvers.forEach {
+        site!!.effectiveDnsResolvers.forEach {
             hasDnsResolvers = true
             builder.addDnsServer(it)
             Log.i(TAG, "Adding dns resolver: $it")

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -216,7 +216,8 @@ data class UnsafeRoute(
  * Saves a site JSON string to disk. Extracts key and dnCredentials into
  * encrypted storage, handles the always-on file, and writes the remaining
  * config to config.json. Returns the site directory.
- * If existingSite is provided, client-only fields (sortKey, excludedApps) will be preserved from it.
+ * If existingSite is provided, client-only fields (sortKey, excludedApps, lastManagedUpdate,
+ * dnsResolvers and matchDomains) will be preserved from it.
  */
 fun saveSite(context: Context, jsonString: String, existingSite: Site? = null): File {
     val gson = Gson()
@@ -271,10 +272,19 @@ fun saveSite(context: Context, jsonString: String, existingSite: Site? = null): 
         if (!map.containsKey("excludedApps")) {
             map["excludedApps"] = existingSite.excludedApps
         }
+        if (!map.containsKey("lastManagedUpdate")) {
+            map["lastManagedUpdate"] = existingSite.lastManagedUpdate
+        }
+        if (!map.containsKey("dnsResolvers")) {
+            map["dnsResolvers"] = existingSite.localDnsResolvers
+        }
+        if (!map.containsKey("matchDomains")) {
+            map["matchDomains"] = existingSite.localMatchDomains
+        }
     }
 
     // Stamp the current config version
-    map["configVersion"] = 1
+    map["configVersion"] = mobileNebula.MobileNebula.CurrentConfigVersion
 
     // Write the remaining config to disk
     val confFile = siteDir.resolve("config.json")
@@ -302,10 +312,28 @@ class Site(context: Context, siteDir: File) {
     var excludedApps: List<String> = ArrayList()
     val alwaysOn: Boolean
 
+    // Client owned dns settings. null means no local override, which is different from an empty
+    // list, that means the user deliberately cleared what their admin handed them.
+    @SerializedName("dnsResolvers")
+    val localDnsResolvers: List<String>?
+    @SerializedName("matchDomains")
+    val localMatchDomains: List<String>?
+
     // Fields parsed from rawConfig for VPN service use
     val mtu: Int
     val unsafeRoutes: List<UnsafeRoute>
-    val dnsResolvers: List<String>
+
+    @Transient
+    val managedDnsResolvers: List<String>
+    @Transient
+    val allowLocalDnsOverride: Boolean
+
+    /**
+     * The resolvers the tunnel should actually use. Note that managed never appears in this rule,
+     * an unmanaged site simply has no admin values and nothing locking it.
+     */
+    val effectiveDnsResolvers: List<String>
+        get() = if (!allowLocalDnsOverride) managedDnsResolvers else localDnsResolvers ?: managedDnsResolvers
 
     // Path to this site on disk
     @Transient
@@ -368,12 +396,27 @@ class Site(context: Context, siteDir: File) {
             } ?: emptyList()
         } catch (_: Exception) { emptyList() }
 
-        // Parse dnsResolvers from rawConfig
-        dnsResolvers = try {
-            val mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? Map<*, *>
+        // Client owned dns settings live at the top level, an absent key is not an empty list
+        @Suppress("UNCHECKED_CAST")
+        localDnsResolvers = (siteMap["dnsResolvers"] as? List<*>)?.mapNotNull { it?.toString() }
+        @Suppress("UNCHECKED_CAST")
+        localMatchDomains = (siteMap["matchDomains"] as? List<*>)?.mapNotNull { it?.toString() }
+
+        // Admin supplied dns settings live in rawConfig, which belongs to DN.
+        //
+        // TODO: these key names are a placeholder, they have to match whatever dnclient settles
+        // on. The DN side of this does not exist in dnapi yet.
+        val mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? Map<*, *>
+
+        managedDnsResolvers = try {
             val resolvers = mobileNebulaConfig?.get("dns_resolvers") as? List<*>
             resolvers?.mapNotNull { it?.toString() } ?: emptyList()
         } catch (_: Exception) { emptyList() }
+
+        // Absent has to mean allowed. Every config written before this shipped lacks the flag, and
+        // so does every DN backend until the server side lands, so failing closed would lock dns
+        // resolvers on every managed site the moment someone takes the app update.
+        allowLocalDnsOverride = mobileNebulaConfig?.get("allow_local_dns_override") as? Boolean ?: true
 
         // Parse cert from rawConfig's pki.cert
         val pki = rawConfigMap["pki"] as? Map<*, *>

--- a/ios/NebulaNetworkExtension/ConfigMigrator.swift
+++ b/ios/NebulaNetworkExtension/ConfigMigrator.swift
@@ -2,44 +2,38 @@ import Foundation
 import MobileNebula
 
 enum ConfigMigrator {
-  /// Migrates config data to the latest version if needed.
-  /// Writes the migrated config back to disk and returns the updated data.
+  /// Brings a site config up to date and writes it back to disk if anything changed.
+  ///
+  /// The migrations themselves all live in Go. This knows nothing about individual versions, it
+  /// only supplies the private key that Go can't reach and handles the file, so adding a
+  /// migration should not need a change here.
   static func migrate(configData: Data, path: URL) throws -> Data {
-    guard let configMap = try? JSONSerialization.jsonObject(with: configData) as? [String: Any]
-    else {
-      return configData
-    }
-
-    var version = configMap["configVersion"] as? Int ?? 0
-    var result = configData
-
-    if version < 1 {
-      result = try migrateToV1(configData: result, configMap: configMap, path: path)
-      version = 1
-    }
-
-    // Future migrations go here
-
-    return result
-  }
-
-  /// Migrates from v0 (old decomposed format) to v1 (rawConfig format).
-  private static func migrateToV1(
-    configData: Data, configMap: [String: Any], path: URL
-  ) throws -> Data {
-    let siteId = configMap["id"] as? String ?? ""
-    let key: String
-    if let keyData = KeyChain.load(key: "\(siteId).key") {
-      key = String(decoding: keyData, as: UTF8.self)
-    } else {
-      key = ""
-    }
-
     let oldJson = String(data: configData, encoding: .utf8) ?? "{}"
+
+    // Only the legacy format needs the key, so don't pay for a keychain read on every site load
+    var key = ""
+    if MobileNebulaMigrationNeedsKey(oldJson) {
+      var siteId = ""
+      if let obj = try? JSONSerialization.jsonObject(with: configData),
+        let configMap = obj as? [String: Any]
+      {
+        siteId = configMap["id"] as? String ?? ""
+      }
+
+      if let keyData = KeyChain.load(key: "\(siteId).key") {
+        key = String(decoding: keyData, as: UTF8.self)
+      }
+    }
+
     var err: NSError?
     let newJson = MobileNebulaMigrateConfig(oldJson, key, &err)
     if let err = err {
       throw err
+    }
+
+    // Go hands back the input verbatim when there is nothing to do
+    if newJson == oldJson {
+      return configData
     }
 
     guard let newData = newJson.data(using: .utf8) else {

--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -160,15 +160,16 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       unsafeRoutes: _site.unsafeRoutes
     )
 
-    if !_site.dnsResolvers.isEmpty {
-      self.log.info("Assigning dns resolvers: \(_site.dnsResolvers, privacy: .public)")
-      let dnsSettings = NEDNSSettings(servers: _site.dnsResolvers)
-      if _site.matchDomains.isEmpty {
+    let resolvers = _site.effectiveDnsResolvers
+    if !resolvers.isEmpty {
+      self.log.info("Assigning dns resolvers: \(resolvers, privacy: .public)")
+      let dnsSettings = NEDNSSettings(servers: resolvers)
+      if _site.effectiveMatchDomains.isEmpty {
         // An empty string in matchDomains means "match all domains", which tells iOS to
         // actually route DNS queries through these servers. Without this, iOS ignores them.
         dnsSettings.matchDomains = [""]
       } else {
-        dnsSettings.matchDomains = _site.matchDomains
+        dnsSettings.matchDomains = _site.effectiveMatchDomains
       }
       tunnelNetworkSettings.dnsSettings = dnsSettings
     }

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -159,7 +159,8 @@ class UnsafeRoute: Codable {
 
 /// Saves a site JSON string to disk. Extracts key and dnCredentials into
 /// encrypted storage and writes the remaining config to config.json.
-/// If existingSite is provided, client-only fields (sortKey) will be preserved from it.
+/// If existingSite is provided, client-only fields (sortKey, lastManagedUpdate, dnsResolvers and
+/// matchDomains) will be preserved from it.
 func saveSiteToDisk(jsonString: String, existingSite: Site? = nil) throws {
   guard let jsonData = jsonString.data(using: .utf8),
     let obj = try? JSONSerialization.jsonObject(with: jsonData),
@@ -201,10 +202,19 @@ func saveSiteToDisk(jsonString: String, existingSite: Site? = nil) throws {
     if map["sortKey"] == nil {
       map["sortKey"] = existingSite.sortKey
     }
+    if map["lastManagedUpdate"] == nil {
+      map["lastManagedUpdate"] = existingSite.lastManagedUpdate
+    }
+    if map["dnsResolvers"] == nil {
+      map["dnsResolvers"] = existingSite.localDnsResolvers
+    }
+    if map["matchDomains"] == nil {
+      map["matchDomains"] = existingSite.localMatchDomains
+    }
   }
 
   // Stamp the current config version
-  map["configVersion"] = 1
+  map["configVersion"] = MobileNebulaCurrentConfigVersion
 
   // Write the remaining config to disk
   let configPath = try SiteList.getSiteConfigFile(id: id, createDir: true)
@@ -329,11 +339,33 @@ class Site: Encodable {
   var alwaysOn: Bool
   var errors: [String]
 
+  // Client owned dns settings. nil means no local override, which is different from an empty
+  // list, that means the user deliberately cleared what their admin handed them.
+  var localDnsResolvers: [String]?
+  var localMatchDomains: [String]?
+
   // Fields parsed from rawConfig for VPN service use (not encoded to Flutter)
   var mtu: Int
   var unsafeRoutes: [UnsafeRoute]
-  var dnsResolvers: [String]
-  var matchDomains: [String]
+  var managedDnsResolvers: [String]
+  var managedMatchDomains: [String]
+  var allowLocalDnsOverride: Bool
+
+  /// The resolvers the tunnel should actually use. Note that managed never appears in this rule,
+  /// an unmanaged site simply has no admin values and nothing locking it.
+  var effectiveDnsResolvers: [String] {
+    if !allowLocalDnsOverride {
+      return managedDnsResolvers
+    }
+    return localDnsResolvers ?? managedDnsResolvers
+  }
+
+  var effectiveMatchDomains: [String] {
+    if !allowLocalDnsOverride {
+      return managedMatchDomains
+    }
+    return localMatchDomains ?? managedMatchDomains
+  }
 
   /// If true then this site needs to be migrated to the filesystem. Should be handled by the initiator of the site
   var needsToMigrateToFS: Bool = false
@@ -448,19 +480,22 @@ class Site: Encodable {
       unsafeRoutes = []
     }
 
-    // Parse dnsResolvers from rawConfig
-    let mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? [String: Any]
-    if let resolvers = mobileNebulaConfig?["dns_resolvers"] as? [String] {
-      dnsResolvers = resolvers
-    } else {
-      dnsResolvers = []
-    }
+    // Client owned dns settings live at the top level, an absent key is not an empty list
+    localDnsResolvers = configMap["dnsResolvers"] as? [String]
+    localMatchDomains = configMap["matchDomains"] as? [String]
 
-    if let domains = mobileNebulaConfig?["match_domains"] as? [String] {
-      matchDomains = domains
-    } else {
-      matchDomains = []
-    }
+    // Admin supplied dns settings live in rawConfig, which belongs to DN.
+    //
+    // TODO: these key names are a placeholder, they have to match whatever dnclient settles on.
+    // The DN side of this does not exist in dnapi yet.
+    let mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? [String: Any]
+    managedDnsResolvers = mobileNebulaConfig?["dns_resolvers"] as? [String] ?? []
+    managedMatchDomains = mobileNebulaConfig?["match_domains"] as? [String] ?? []
+
+    // Absent has to mean allowed. Every config written before this shipped lacks the flag, and so
+    // does every DN backend until the server side lands, so failing closed would lock dns
+    // resolvers on every managed site the moment someone takes the app update.
+    allowLocalDnsOverride = mobileNebulaConfig?["allow_local_dns_override"] as? Bool ?? true
 
     // Parse cert from rawConfig's pki.cert
     let pki = rawConfigMap["pki"] as? [String: Any]
@@ -618,6 +653,8 @@ class Site: Encodable {
     case logFile
     case alwaysOn
     case errors
+    case localDnsResolvers = "dnsResolvers"
+    case localMatchDomains = "matchDomains"
   }
 }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -161,8 +161,9 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
         return result(CallFailedError(message: "Failed to parse enrollment response"))
       }
 
+      // Re-enrolling an existing host keeps its client side settings
       let oldSite = self.sites?.getSite(id: id)
-      saveSite(jsonString: json, manager: oldSite?.manager) { error in
+      saveSite(jsonString: json, manager: oldSite?.manager, existingSite: oldSite) { error in
         if error != nil {
           return result(
             CallFailedError(message: "Failed to enroll", details: error!.localizedDescription))
@@ -216,7 +217,7 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
     }
 
     let oldSite = self.sites?.getSite(id: id)
-    saveSite(jsonString: json, manager: oldSite?.manager) { error in
+    saveSite(jsonString: json, manager: oldSite?.manager, existingSite: oldSite) { error in
       if error != nil {
         return result(
           CallFailedError(message: "Failed to save site", details: error!.localizedDescription))

--- a/lib/models/site.dart
+++ b/lib/models/site.dart
@@ -47,6 +47,11 @@ class Site {
   late bool alwaysOn;
   late List<String> excludedApps;
 
+  // Client owned dns settings. null means no local override, which is different from an empty
+  // list, that means the user deliberately cleared what their admin handed them.
+  late List<String>? dnsResolvers;
+  late List<String>? matchDomains;
+
   // DN management
   late bool managed;
   late DateTime? lastManagedUpdate;
@@ -70,6 +75,8 @@ class Site {
     this.lastManagedUpdate,
     this.alwaysOn = false,
     List<String>? excludedApps,
+    this.dnsResolvers,
+    this.matchDomains,
   }) {
     this.id = id ?? uuid.v4();
     this.rawConfig = rawConfig ?? {};
@@ -119,6 +126,8 @@ class Site {
       lastManagedUpdate: decoded['lastManagedUpdate'],
       alwaysOn: decoded['alwaysOn'],
       excludedApps: decoded['excludedApps'],
+      dnsResolvers: decoded['dnsResolvers'],
+      matchDomains: decoded['matchDomains'],
     );
   }
 
@@ -128,6 +137,19 @@ class Site {
     }
 
     final rawConfig = _yamlToMap(yaml);
+
+    // An imported yaml has no admin behind it, so hoist any dns settings to the local override
+    // the same way the v2 migration does rather than leaving them looking managed.
+    List<String>? dnsResolvers;
+    List<String>? matchDomains;
+    if (rawConfig['mobile_nebula'] is Map<String, dynamic>) {
+      final mobileNebula = rawConfig['mobile_nebula'] as Map<String, dynamic>;
+      dnsResolvers = _optionalStringList(mobileNebula.remove('dns_resolvers'));
+      matchDomains = _optionalStringList(mobileNebula.remove('match_domains'));
+      if (mobileNebula.isEmpty) {
+        rawConfig.remove('mobile_nebula');
+      }
+    }
 
     // Extract and remove pki.key from rawConfig
     String? key;
@@ -186,7 +208,14 @@ class Site {
       }
     }
 
-    return Site(rawConfig: rawConfig, ca: ca, certInfo: certInfo, errors: errors)..key = key;
+    return Site(
+      rawConfig: rawConfig,
+      ca: ca,
+      certInfo: certInfo,
+      errors: errors,
+      dnsResolvers: dnsResolvers,
+      matchDomains: matchDomains,
+    )..key = key;
   }
 
   void _updateFromJson(String json) {
@@ -206,6 +235,8 @@ class Site {
     lastManagedUpdate = decoded['lastManagedUpdate'];
     alwaysOn = decoded['alwaysOn'];
     excludedApps = decoded['excludedApps'];
+    dnsResolvers = decoded['dnsResolvers'];
+    matchDomains = decoded['matchDomains'];
   }
 
   static Map<String, dynamic> _fromJson(Map<String, dynamic> json) {
@@ -259,7 +290,15 @@ class Site {
       "lastManagedUpdate": json["lastManagedUpdate"] == null ? null : DateTime.parse(json["lastManagedUpdate"]),
       "alwaysOn": json['alwaysOn'] ?? false,
       "excludedApps": excludedApps,
+      "dnsResolvers": _optionalStringList(json['dnsResolvers']),
+      "matchDomains": _optionalStringList(json['matchDomains']),
     };
+  }
+
+  /// Null and a list are meaningfully different here, so don't collapse a missing key to [].
+  static List<String>? _optionalStringList(dynamic raw) {
+    if (raw is! List) return null;
+    return raw.map((v) => v.toString()).toList();
   }
 
   Stream onChange() {
@@ -277,6 +316,8 @@ class Site {
       'key': key,
       'alwaysOn': alwaysOn,
       'excludedApps': excludedApps,
+      'dnsResolvers': dnsResolvers,
+      'matchDomains': matchDomains,
     };
   }
 
@@ -311,12 +352,6 @@ class Site {
     final routes = _getConfig<List<dynamic>>(['tun', 'unsafe_routes']);
     if (routes == null) return [];
     return routes.map((r) => UnsafeRoute.fromJson(Map<String, dynamic>.from(r))).toList();
-  }
-
-  List<String> get dnsResolvers {
-    final resolvers = _getConfig<List<dynamic>>(['mobile_nebula', 'dns_resolvers']);
-    if (resolvers == null) return [];
-    return resolvers.map((r) => r.toString()).toList();
   }
 
   Map<String, StaticHost> get staticHostmap {
@@ -355,18 +390,40 @@ class Site {
     _setConfig(['tun', 'unsafe_routes'], routes.map((r) => r.toJson()).toList());
   }
 
-  set dnsResolvers(List<String> resolvers) {
-    _setConfig(['mobile_nebula', 'dns_resolvers'], resolvers);
+  // Admin supplied dns settings live in rawConfig, which belongs to DN.
+  //
+  // TODO: these key names are a placeholder, they have to match whatever dnclient settles on.
+  // The DN side of this does not exist in dnapi yet.
+  static const _managedDnsResolversPath = ['mobile_nebula', 'dns_resolvers'];
+  static const _managedMatchDomainsPath = ['mobile_nebula', 'match_domains'];
+  static const _allowLocalDnsOverridePath = ['mobile_nebula', 'allow_local_dns_override'];
+
+  List<String> get managedDnsResolvers => _getStringList(_managedDnsResolversPath);
+  List<String> get managedMatchDomains => _getStringList(_managedMatchDomainsPath);
+
+  /// Whether an admin has left local dns overrides turned on.
+  ///
+  /// Absent has to mean allowed. Every config written before this shipped lacks the flag, and so
+  /// does every DN backend until the server side lands, so failing closed would lock dns
+  /// resolvers on every managed site the moment someone takes the app update.
+  bool get allowLocalDnsOverride => _getConfig<bool>(_allowLocalDnsOverridePath) ?? true;
+
+  /// The resolvers the tunnel should actually use. Note that managed never appears in this rule,
+  /// an unmanaged site simply has no admin values and nothing locking it.
+  List<String> get effectiveDnsResolvers {
+    if (!allowLocalDnsOverride) return managedDnsResolvers;
+    return dnsResolvers ?? managedDnsResolvers;
   }
 
-  List<String> get matchDomains {
-    final domains = _getConfig<List<dynamic>>(['mobile_nebula', 'match_domains']);
-    if (domains == null) return [];
-    return domains.map((d) => d.toString()).toList();
+  List<String> get effectiveMatchDomains {
+    if (!allowLocalDnsOverride) return managedMatchDomains;
+    return matchDomains ?? managedMatchDomains;
   }
 
-  set matchDomains(List<String> domains) {
-    _setConfig(['mobile_nebula', 'match_domains'], domains);
+  List<String> _getStringList(List<String> path) {
+    final values = _getConfig<List<dynamic>>(path);
+    if (values == null) return [];
+    return values.map((v) => v.toString()).toList();
   }
 
   List<FirewallRule> get inboundFirewallRules {

--- a/lib/screens/siteConfig/advanced_screen.dart
+++ b/lib/screens/siteConfig/advanced_screen.dart
@@ -32,8 +32,8 @@ class Advanced {
   String verbosity;
   List<UnsafeRoute> unsafeRoutes;
   int mtu;
-  List<String> dnsResolvers;
-  List<String> matchDomains;
+  List<String>? dnsResolvers;
+  List<String>? matchDomains;
   List<String> excludedApps;
   String staticMapNetwork;
 
@@ -74,13 +74,18 @@ class AdvancedScreenState extends State<AdvancedScreen> {
       verbosity: widget.site.logVerbosity,
       unsafeRoutes: widget.site.unsafeRoutes,
       mtu: widget.site.mtu,
-      dnsResolvers: widget.site.dnsResolvers,
-      matchDomains: widget.site.matchDomains,
+      // Null until the user actually edits them, see _effectiveResolvers
+      dnsResolvers: null,
+      matchDomains: null,
       excludedApps: widget.site.excludedApps,
       staticMapNetwork: widget.site.staticMapNetwork,
     );
     super.initState();
   }
+
+  /// Unsaved edits win, otherwise fall back to whatever the site resolves to today.
+  List<String> get _effectiveResolvers => settings.dnsResolvers ?? widget.site.effectiveDnsResolvers;
+  List<String> get _effectiveMatchDomains => settings.matchDomains ?? widget.site.effectiveMatchDomains;
 
   @override
   Widget build(BuildContext context) {
@@ -219,13 +224,17 @@ class AdvancedScreenState extends State<AdvancedScreen> {
               ConfigPageItem(
                 label: Text('DNS resolvers'),
                 labelWidth: 150,
-                content: Text(Utils.itemCountFormat(settings.dnsResolvers.length), textAlign: TextAlign.end),
+                content: Text(Utils.itemCountFormat(_effectiveResolvers.length), textAlign: TextAlign.end),
                 onPressed: () {
                   Utils.openPage(context, (context) {
+                    // DNS resolvers are a client side setting. Managed sites get to change them
+                    // too, unless an admin has turned local overrides off.
+                    final locked = !widget.site.allowLocalDnsOverride;
                     return DnsResolversScreen(
-                      dnsResolvers: settings.dnsResolvers,
-                      matchDomains: settings.matchDomains,
-                      onSave: widget.site.managed
+                      dnsResolvers: _effectiveResolvers,
+                      matchDomains: _effectiveMatchDomains,
+                      lockedByAdmin: locked,
+                      onSave: locked
                           ? null
                           : (resolvers) {
                               setState(() {
@@ -233,7 +242,7 @@ class AdvancedScreenState extends State<AdvancedScreen> {
                                 changed = true;
                               });
                             },
-                      onSaveMatchDomains: widget.site.managed
+                      onSaveMatchDomains: locked
                           ? null
                           : (domains) {
                               setState(() {

--- a/lib/screens/siteConfig/dns_resolvers_screen.dart
+++ b/lib/screens/siteConfig/dns_resolvers_screen.dart
@@ -22,14 +22,24 @@ class _Domain {
 }
 
 class DnsResolversScreen extends StatefulWidget {
-  DnsResolversScreen({super.key, dnsResolvers, matchDomains, required this.onSave, this.onSaveMatchDomains})
-    : dnsResolvers = dnsResolvers ?? [],
-      matchDomains = matchDomains ?? [];
+  DnsResolversScreen({
+    super.key,
+    dnsResolvers,
+    matchDomains,
+    required this.onSave,
+    this.onSaveMatchDomains,
+    this.lockedByAdmin = false,
+  }) : dnsResolvers = dnsResolvers ?? [],
+       matchDomains = matchDomains ?? [];
 
   final List<String> dnsResolvers;
   final List<String> matchDomains;
   final ValueChanged<List<String>>? onSave;
   final ValueChanged<List<String>>? onSaveMatchDomains;
+
+  /// Read-only because an admin turned local overrides off, rather than because there is
+  /// nothing to edit. Worth telling the user which it is.
+  final bool lockedByAdmin;
 
   @override
   DnsResolversScreenState createState() => DnsResolversScreenState();
@@ -47,7 +57,8 @@ class DnsResolversScreenState extends State<DnsResolversScreen> {
       _dnsResolvers[UniqueKey()] = _Resolver(focusNode: FocusNode(), address: address);
     }
 
-    if (_dnsResolvers.isEmpty) {
+    // Only seed a blank row when there is something to type into
+    if (_dnsResolvers.isEmpty && widget.onSave != null) {
       _addResolver();
     }
 
@@ -70,14 +81,16 @@ class DnsResolversScreenState extends State<DnsResolversScreen> {
       child: Column(
         children: [
           ConfigSection(
-            label:
-                'List of dns resolvers to use for lookups.\nAny resolver that isn\'t in your networks or unsafe networks will be routed in plaintext.',
+            label: widget.lockedByAdmin
+                ? 'These resolvers are set by your administrator and can\'t be changed here.'
+                : 'List of dns resolvers to use for lookups.\nAny resolver that isn\'t in your networks or unsafe networks will be routed in plaintext.',
             children: _buildHosts(),
           ),
           if (Platform.isIOS)
             ConfigSection(
-              label:
-                  'Domains to route through the VPN\'s DNS resolvers.\nWhen empty, all DNS queries are routed through the VPN.',
+              label: widget.lockedByAdmin
+                  ? 'Match domains are set by your administrator and can\'t be changed here.'
+                  : 'Domains to route through the VPN\'s DNS resolvers.\nWhen empty, all DNS queries are routed through the VPN.',
               children: _buildDomains(),
             ),
         ],

--- a/lib/screens/siteConfig/site_config_screen.dart
+++ b/lib/screens/siteConfig/site_config_screen.dart
@@ -405,16 +405,27 @@ class SiteConfigScreenState extends State<SiteConfigScreen> {
                 onSave: (settings) {
                   setState(() {
                     changed = true;
-                    site.cipher = settings.cipher;
-                    site.lhDuration = settings.lhDuration;
-                    site.port = settings.port;
-                    site.logVerbosity = settings.verbosity;
-                    site.unsafeRoutes = settings.unsafeRoutes;
-                    site.dnsResolvers = settings.dnsResolvers;
-                    site.matchDomains = settings.matchDomains;
-                    site.mtu = settings.mtu;
+
+                    // A managed site only gets to change the client side settings below, writing
+                    // the rest back would bake our defaults into the config DN handed us.
+                    if (!site.managed) {
+                      site.cipher = settings.cipher;
+                      site.lhDuration = settings.lhDuration;
+                      site.port = settings.port;
+                      site.logVerbosity = settings.verbosity;
+                      site.unsafeRoutes = settings.unsafeRoutes;
+                      site.mtu = settings.mtu;
+                      site.staticMapNetwork = settings.staticMapNetwork;
+                    }
+
+                    // Left null when untouched so the site keeps deferring to its admin
+                    if (settings.dnsResolvers != null) {
+                      site.dnsResolvers = settings.dnsResolvers;
+                    }
+                    if (settings.matchDomains != null) {
+                      site.matchDomains = settings.matchDomains;
+                    }
                     site.excludedApps = settings.excludedApps;
-                    site.staticMapNetwork = settings.staticMapNetwork;
                   });
                 },
               );

--- a/nebula/mobileNebula.go
+++ b/nebula/mobileNebula.go
@@ -147,9 +147,74 @@ func renderConfigLegacy(d map[string]interface{}, key string) (string, error) {
 	return string(finalConfig), nil
 }
 
-// MigrateConfig takes an old-format site JSON (with decomposed fields) and returns a
-// new-format site JSON (with rawConfig). Used by Kotlin/Swift for migration.
-func MigrateConfig(oldConfigJSON string, key string) (string, error) {
+// MigrateConfig brings a site config up to CurrentConfigVersion, running whatever chain of
+// migrations that takes. Kotlin and Swift call this once per site load and know nothing about
+// individual versions, so adding a migration should not need any native changes.
+//
+// It returns configJSON verbatim when there is nothing to do, which lets callers skip the disk
+// write on a plain string comparison.
+//
+// key is only read when migrating a v0 config. Ask MigrationNeedsKey before going and fetching
+// it, on iOS that is a keychain hit we would otherwise take on every site load.
+func MigrateConfig(configJSON string, key string) (string, error) {
+	version, err := configVersion(configJSON)
+	if err != nil {
+		return "", err
+	}
+
+	if version >= CurrentConfigVersion {
+		return configJSON, nil
+	}
+
+	result := configJSON
+
+	if version < 1 {
+		if result, err = migrateToV1(result, key); err != nil {
+			return "", err
+		}
+	}
+
+	if version < 2 {
+		if result, err = migrateToV2(result); err != nil {
+			return "", err
+		}
+	}
+
+	return result, nil
+}
+
+// MigrationNeedsKey reports whether migrating this config requires the site's private key. Only
+// the v0 format does, since it has to render the legacy config to get a rawConfig.
+func MigrationNeedsKey(configJSON string) bool {
+	version, err := configVersion(configJSON)
+	if err != nil {
+		// Let MigrateConfig report the parse failure, meanwhile assume the key is wanted
+		return true
+	}
+
+	return version < 1
+}
+
+// configVersion reads configVersion off a site config. A config without one is a v0.
+func configVersion(configJSON string) (int, error) {
+	var probe struct {
+		ConfigVersion *int `json:"configVersion"`
+	}
+
+	if err := json.Unmarshal([]byte(configJSON), &probe); err != nil {
+		return 0, fmt.Errorf("failed to parse config: %s", err)
+	}
+
+	if probe.ConfigVersion == nil {
+		return 0, nil
+	}
+
+	return *probe.ConfigVersion, nil
+}
+
+// migrateToV1 takes an old-format site JSON (with decomposed fields) and returns a
+// new-format site JSON (with rawConfig).
+func migrateToV1(oldConfigJSON string, key string) (string, error) {
 	var old legacySite
 	if err := json.Unmarshal([]byte(oldConfigJSON), &old); err != nil {
 		return "", fmt.Errorf("failed to parse old config: %s", err)
@@ -216,6 +281,58 @@ func MigrateConfig(oldConfigJSON string, key string) (string, error) {
 	}
 
 	newJSON, err := json.Marshal(newSite)
+	if err != nil {
+		return "", err
+	}
+
+	return string(newJSON), nil
+}
+
+// migrateToV2 takes a v1 site JSON and returns a v2 one. It hoists the client owned dns
+// settings out of rawConfig.mobile_nebula and up to the top level of the site config.
+//
+// rawConfig belongs to DN, so mobile_nebula.dns_resolvers is now the admin supplied list and the
+// local override lives at the top level next to excludedApps. The old values have to move rather
+// than be copied, otherwise a user's resolvers would come back looking like an admin's.
+func migrateToV2(configJSON string) (string, error) {
+	var site map[string]interface{}
+	if err := json.Unmarshal([]byte(configJSON), &site); err != nil {
+		return "", fmt.Errorf("failed to parse config: %s", err)
+	}
+
+	if rawConfigStr, ok := site["rawConfig"].(string); ok && rawConfigStr != "" {
+		var rawConfig map[string]interface{}
+		if err := json.Unmarshal([]byte(rawConfigStr), &rawConfig); err != nil {
+			return "", fmt.Errorf("failed to parse rawConfig: %s", err)
+		}
+
+		if mobileNebula, ok := rawConfig["mobile_nebula"].(map[string]interface{}); ok {
+			if v, ok := mobileNebula["dns_resolvers"]; ok {
+				site["dnsResolvers"] = v
+				delete(mobileNebula, "dns_resolvers")
+			}
+
+			if v, ok := mobileNebula["match_domains"]; ok {
+				site["matchDomains"] = v
+				delete(mobileNebula, "match_domains")
+			}
+
+			if len(mobileNebula) == 0 {
+				delete(rawConfig, "mobile_nebula")
+			}
+
+			rawConfigBytes, err := json.Marshal(rawConfig)
+			if err != nil {
+				return "", err
+			}
+
+			site["rawConfig"] = string(rawConfigBytes)
+		}
+	}
+
+	site["configVersion"] = CurrentConfigVersion
+
+	newJSON, err := json.Marshal(site)
 	if err != nil {
 		return "", err
 	}

--- a/nebula/mobileNebula_test.go
+++ b/nebula/mobileNebula_test.go
@@ -3,6 +3,7 @@ package mobileNebula
 import (
 	"encoding/json"
 	"log/slog"
+	"strconv"
 	"testing"
 
 	nebcfg "github.com/slackhq/nebula/config"
@@ -208,7 +209,8 @@ func TestMigrateConfig_ConfigVersion(t *testing.T) {
 	err = json.Unmarshal([]byte(newConfig), &newSite)
 	require.NoError(t, err)
 
-	assert.Equal(t, float64(1), newSite["configVersion"], "migrated config should have configVersion 1")
+	assert.Equal(t, float64(CurrentConfigVersion), newSite["configVersion"],
+		"MigrateConfig should run the whole chain, not stop at v1")
 }
 
 func TestMigrateConfig_KeyStripped(t *testing.T) {
@@ -248,7 +250,8 @@ func TestMigrateConfig_KeyStripped(t *testing.T) {
 }
 
 func TestMigrateConfig_DnsResolvers(t *testing.T) {
-	// Old-format site with dnsResolvers — should be preserved under mobile_nebula.dns_resolvers
+	// Old-format site with dnsResolvers. v1 parks them under mobile_nebula and v2 hoists them
+	// back to the top level, so a full chain run should land them there.
 	oldConfig := `{
   "name": "DNS Test",
   "id": "dns-test-id",
@@ -276,16 +279,9 @@ func TestMigrateConfig_DnsResolvers(t *testing.T) {
 	err = json.Unmarshal([]byte(newSite["rawConfig"].(string)), &rawConfig)
 	require.NoError(t, err)
 
-	// dnsResolvers should be under mobile_nebula namespace
-	mobileNebula, ok := rawConfig["mobile_nebula"].(map[string]interface{})
-	require.True(t, ok, "rawConfig should have mobile_nebula key")
-
-	resolvers, ok := mobileNebula["dns_resolvers"].([]interface{})
-	require.True(t, ok, "mobile_nebula should have dns_resolvers")
-	assert.Equal(t, []interface{}{"1.1.1.1", "8.8.8.8"}, resolvers)
-
-	// dnsResolvers should NOT be at the top level of rawConfig
-	assert.NotContains(t, rawConfig, "dnsResolvers", "dnsResolvers should not be at rawConfig top level")
+	// The local override is a first class field, rawConfig belongs to DN
+	assert.Equal(t, []interface{}{"1.1.1.1", "8.8.8.8"}, newSite["dnsResolvers"])
+	assert.NotContains(t, rawConfig, "mobile_nebula", "dns settings should not be left in rawConfig")
 }
 
 func TestMigrateConfig_NoDnsResolvers(t *testing.T) {
@@ -346,7 +342,7 @@ func TestMigrateConfig_ManagedWithRawConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, true, newSite["managed"])
-	assert.Equal(t, float64(1), newSite["configVersion"])
+	assert.Equal(t, float64(CurrentConfigVersion), newSite["configVersion"])
 
 	// rawConfig should be JSON (converted from old YAML)
 	var rawConfig map[string]interface{}
@@ -398,4 +394,158 @@ cipher: aes
 	pki, ok := result["pki"].(map[string]interface{})
 	require.True(t, ok, "pki should be a map")
 	assert.Equal(t, "test-ca", pki["ca"])
+}
+
+// migrateV2 runs a v1 config through MigrateConfig and returns the site map plus its rawConfig.
+func migrateV2(t *testing.T, configJSON string) (map[string]interface{}, map[string]interface{}) {
+	t.Helper()
+
+	newConfig, err := MigrateConfig(configJSON, "")
+	require.NoError(t, err)
+
+	var site map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(newConfig), &site))
+
+	rawConfig := map[string]interface{}{}
+	if s, ok := site["rawConfig"].(string); ok && s != "" {
+		require.NoError(t, json.Unmarshal([]byte(s), &rawConfig))
+	}
+
+	return site, rawConfig
+}
+
+func TestMigrateConfigV2_HoistsDnsSettings(t *testing.T) {
+	rawConfig := `{"pki":{"cert":"c"},"listen":{"port":4242},"mobile_nebula":{"dns_resolvers":["1.1.1.1","8.8.8.8"],"match_domains":["example.com"]}}`
+	configJSON := `{"name":"n","id":"i","configVersion":1,"rawConfig":` + strconv.Quote(rawConfig) + `}`
+
+	site, newRaw := migrateV2(t, configJSON)
+
+	assert.Equal(t, []interface{}{"1.1.1.1", "8.8.8.8"}, site["dnsResolvers"])
+	assert.Equal(t, []interface{}{"example.com"}, site["matchDomains"])
+	assert.Equal(t, float64(2), site["configVersion"])
+
+	// The values must move, not copy. A leftover would read back as an admin supplied list.
+	assert.NotContains(t, newRaw, "mobile_nebula", "empty mobile_nebula should be dropped")
+
+	// Everything else in rawConfig is untouched, including number types
+	listen, ok := newRaw["listen"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, float64(4242), listen["port"])
+}
+
+func TestMigrateConfigV2_KeepsOtherMobileNebulaKeys(t *testing.T) {
+	rawConfig := `{"mobile_nebula":{"dns_resolvers":["1.1.1.1"],"allow_local_dns_override":false}}`
+	configJSON := `{"name":"n","id":"i","configVersion":1,"rawConfig":` + strconv.Quote(rawConfig) + `}`
+
+	site, newRaw := migrateV2(t, configJSON)
+
+	assert.Equal(t, []interface{}{"1.1.1.1"}, site["dnsResolvers"])
+
+	mobileNebula, ok := newRaw["mobile_nebula"].(map[string]interface{})
+	require.True(t, ok, "mobile_nebula should survive when it still holds keys")
+	assert.Equal(t, false, mobileNebula["allow_local_dns_override"])
+	assert.NotContains(t, mobileNebula, "dns_resolvers")
+}
+
+func TestMigrateConfigV2_NoDnsSettings(t *testing.T) {
+	rawConfig := `{"pki":{"cert":"c"}}`
+	configJSON := `{"name":"n","id":"i","configVersion":1,"rawConfig":` + strconv.Quote(rawConfig) + `}`
+
+	site, newRaw := migrateV2(t, configJSON)
+
+	assert.NotContains(t, site, "dnsResolvers", "no local override should be invented")
+	assert.NotContains(t, site, "matchDomains")
+	assert.Equal(t, float64(2), site["configVersion"])
+	assert.Contains(t, newRaw, "pki")
+}
+
+func TestMigrateConfigV2_EmptyListIsPreserved(t *testing.T) {
+	// An empty list means the user explicitly cleared their resolvers, which is different from
+	// never having set any. Absent falls back to the admin's list, empty does not.
+	rawConfig := `{"mobile_nebula":{"dns_resolvers":[]}}`
+	configJSON := `{"name":"n","id":"i","configVersion":1,"rawConfig":` + strconv.Quote(rawConfig) + `}`
+
+	site, _ := migrateV2(t, configJSON)
+
+	require.Contains(t, site, "dnsResolvers")
+	assert.Equal(t, []interface{}{}, site["dnsResolvers"])
+}
+
+func TestMigrateConfigV2_IsIdempotent(t *testing.T) {
+	rawConfig := `{"mobile_nebula":{"dns_resolvers":["1.1.1.1"]}}`
+	configJSON := `{"name":"n","id":"i","configVersion":1,"rawConfig":` + strconv.Quote(rawConfig) + `}`
+
+	once, err := MigrateConfig(configJSON, "")
+	require.NoError(t, err)
+	twice, err := MigrateConfig(once, "")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, once, twice)
+}
+
+func TestMigrateConfigV2_ChainsFromV0(t *testing.T) {
+	// A legacy site migrates v0 -> v1 -> v2 and lands with its resolvers at the top level
+	oldConfig := `{
+  "name": "Chained",
+  "id": "chained-id",
+  "staticHostmap": {},
+  "unsafeRoutes": [],
+  "ca": "ca",
+  "cert": "cert",
+  "lhDuration": 60,
+  "port": 4242,
+  "mtu": 1300,
+  "cipher": "aes",
+  "sortKey": 0,
+  "logVerbosity": "info",
+  "dnsResolvers": ["1.1.1.1", "8.8.8.8"]
+}`
+
+	site, newRaw := migrateV2(t, oldConfig)
+
+	assert.Equal(t, []interface{}{"1.1.1.1", "8.8.8.8"}, site["dnsResolvers"])
+	assert.NotContains(t, newRaw, "mobile_nebula")
+	assert.Equal(t, float64(2), site["configVersion"])
+}
+
+func TestMigrateConfigV2_BadRawConfigErrors(t *testing.T) {
+	configJSON := `{"name":"n","id":"i","configVersion":1,"rawConfig":"not json"}`
+
+	_, err := MigrateConfig(configJSON, "")
+	assert.Error(t, err, "a corrupt rawConfig should not be silently dropped")
+}
+
+func TestMigrateConfig_CurrentVersionIsVerbatim(t *testing.T) {
+	// Kotlin and Swift skip the disk write by comparing strings, so a no-op has to be byte
+	// identical rather than merely equivalent
+	configJSON := `{"name":"n","id":"i","configVersion":2,"rawConfig":"{}","dnsResolvers":["1.1.1.1"]}`
+
+	result, err := MigrateConfig(configJSON, "")
+	require.NoError(t, err)
+	assert.Equal(t, configJSON, result)
+}
+
+func TestMigrateConfig_FutureVersionIsLeftAlone(t *testing.T) {
+	// An older build should not mangle a config a newer one wrote
+	configJSON := `{"name":"n","id":"i","configVersion":99,"rawConfig":"{}"}`
+
+	result, err := MigrateConfig(configJSON, "")
+	require.NoError(t, err)
+	assert.Equal(t, configJSON, result)
+}
+
+func TestMigrateConfig_BadJsonErrors(t *testing.T) {
+	_, err := MigrateConfig("not json", "")
+	assert.Error(t, err)
+}
+
+func TestMigrationNeedsKey(t *testing.T) {
+	// Only the legacy format needs it, everything else avoids a keychain hit per site load
+	assert.True(t, MigrationNeedsKey(`{"name":"n","id":"i"}`), "a v0 config has no version stamp")
+	assert.True(t, MigrationNeedsKey(`{"name":"n","id":"i","configVersion":0}`))
+	assert.False(t, MigrationNeedsKey(`{"name":"n","id":"i","configVersion":1}`))
+	assert.False(t, MigrationNeedsKey(`{"name":"n","id":"i","configVersion":2}`))
+
+	// Unparseable falls back to asking for the key, MigrateConfig reports the real failure
+	assert.True(t, MigrationNeedsKey("not json"))
 }

--- a/nebula/site.go
+++ b/nebula/site.go
@@ -8,6 +8,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// CurrentConfigVersion is the config.json schema version this build writes. Kotlin and Swift
+// stamp it on every save and run their migration chain up to it on every load.
+const CurrentConfigVersion = 2
+
 // site represents an IncomingSite in Kotlin/Swift.
 type site struct {
 	Name              string         `json:"name"`
@@ -65,7 +69,7 @@ func newDNSite(name string, rawCfg []byte, key string, creds keys.Credentials) (
 		LastManagedUpdate: &now,
 		RawConfig:         string(rawConfigBytes),
 		Key:               &key,
-		ConfigVersion:     1,
+		ConfigVersion:     CurrentConfigVersion,
 		DNCredentials: &dnCredentials{
 			HostID:      creds.HostID,
 			PrivateKey:  string(pkm),

--- a/test/models/site_test.dart
+++ b/test/models/site_test.dart
@@ -385,4 +385,104 @@ listen:
       expect(rawConfig['cipher'], 'aes');
     });
   });
+
+  group('dns resolvers', () {
+    Site siteWith({List<String>? local, List<String>? managed, bool? allowOverride}) {
+      final mobileNebula = <String, dynamic>{};
+      if (managed != null) mobileNebula['dns_resolvers'] = managed;
+      if (allowOverride != null) mobileNebula['allow_local_dns_override'] = allowOverride;
+
+      return Site(rawConfig: mobileNebula.isEmpty ? {} : {'mobile_nebula': mobileNebula}, dnsResolvers: local);
+    }
+
+    test('local override wins over the admin list', () {
+      final site = siteWith(local: ['10.0.0.1'], managed: ['1.1.1.1']);
+      expect(site.effectiveDnsResolvers, ['10.0.0.1']);
+    });
+
+    test('falls back to the admin list when there is no local override', () {
+      final site = siteWith(managed: ['1.1.1.1']);
+      expect(site.dnsResolvers, isNull);
+      expect(site.effectiveDnsResolvers, ['1.1.1.1']);
+    });
+
+    test('an empty local list is an override, not an absent one', () {
+      // The user deliberately cleared what their admin handed them
+      final site = siteWith(local: [], managed: ['1.1.1.1']);
+      expect(site.effectiveDnsResolvers, isEmpty);
+    });
+
+    test('admin can lock local overrides off', () {
+      final site = siteWith(local: ['10.0.0.1'], managed: ['1.1.1.1'], allowOverride: false);
+      expect(site.allowLocalDnsOverride, isFalse);
+      expect(site.effectiveDnsResolvers, ['1.1.1.1']);
+    });
+
+    test('a locked site keeps the local value dormant rather than dropping it', () {
+      final site = siteWith(local: ['10.0.0.1'], managed: ['1.1.1.1'], allowOverride: false);
+      expect(site.dnsResolvers, ['10.0.0.1'], reason: 'must survive so unlocking restores it');
+    });
+
+    test('missing policy flag means overrides are allowed', () {
+      // Every config predates the flag, failing closed would lock every managed site on upgrade
+      final site = siteWith(local: ['10.0.0.1'], managed: ['1.1.1.1']);
+      expect(site.allowLocalDnsOverride, isTrue);
+      expect(site.effectiveDnsResolvers, ['10.0.0.1']);
+    });
+
+    test('nothing set anywhere resolves to empty', () {
+      expect(siteWith().effectiveDnsResolvers, isEmpty);
+      expect(siteWith().effectiveMatchDomains, isEmpty);
+    });
+
+    test('unmanaged sites go through the same rule', () {
+      final site = Site(dnsResolvers: ['10.0.0.1']);
+      expect(site.managed, isFalse);
+      expect(site.allowLocalDnsOverride, isTrue);
+      expect(site.effectiveDnsResolvers, ['10.0.0.1']);
+    });
+
+    test('round trips through toJson', () {
+      final site = Site(dnsResolvers: ['10.0.0.1'], matchDomains: ['example.com']);
+      final json = site.toJson();
+      expect(json['dnsResolvers'], ['10.0.0.1']);
+      expect(json['matchDomains'], ['example.com']);
+    });
+
+    test('toJson keeps null distinct from empty', () {
+      expect(Site().toJson()['dnsResolvers'], isNull);
+      expect(Site(dnsResolvers: []).toJson()['dnsResolvers'], isEmpty);
+    });
+
+    test('parseJson keeps null distinct from empty', () {
+      expect(Site.parseJson({'name': 'n', 'id': 'i'})['dnsResolvers'], isNull);
+      expect(Site.parseJson({'name': 'n', 'id': 'i', 'dnsResolvers': []})['dnsResolvers'], isEmpty);
+      expect(
+        Site.parseJson({
+          'name': 'n',
+          'id': 'i',
+          'dnsResolvers': ['1.1.1.1'],
+        })['dnsResolvers'],
+        ['1.1.1.1'],
+      );
+    });
+
+    test('fromYaml hoists dns settings to the local override', () async {
+      final site = await Site.fromYaml(
+        loadYaml('''
+mobile_nebula:
+  dns_resolvers:
+    - 10.0.0.1
+  match_domains:
+    - example.com
+'''),
+      );
+
+      expect(site.dnsResolvers, ['10.0.0.1']);
+      expect(site.matchDomains, ['example.com']);
+      // An imported yaml has no admin behind it, so nothing should look managed
+      expect(site.managedDnsResolvers, isEmpty);
+      expect(site.rawConfig.containsKey('mobile_nebula'), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
Also adds some stubs to allow a dn admin from locking out local configuration, this feature does not exist in dn yet.