### PR TITLE
Resolve site DNS settings through a shared Go helper

### DIFF
--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/ConfigMigrator.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/ConfigMigrator.kt
@@ -19,6 +19,11 @@ object ConfigMigrator {
             version = 1
         }
 
+        if (version < 2) {
+            result = migrateToV2(siteDir, result)
+            version = 2
+        }
+
         // Future migrations go here
 
         return result
@@ -34,6 +39,13 @@ object ConfigMigrator {
         } catch (_: Exception) { "" }
 
         val migrated = mobileNebula.MobileNebula.migrateConfig(configJson, key)
+        siteDir.resolve("config.json").writeText(migrated)
+        return migrated
+    }
+
+    /** Migrates from v1 to v2: mobile_nebula DNS settings move to the top-level dnsOverride field. */
+    private fun migrateToV2(siteDir: File, configJson: String): String {
+        val migrated = mobileNebula.MobileNebula.migrateConfigV2(configJson)
         siteDir.resolve("config.json").writeText(migrated)
         return migrated
     }

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/MainActivity.kt
@@ -275,6 +275,7 @@ class MainActivity: FlutterActivity() {
         val siteDir: File
         try {
             val json = apiClient!!.enroll(code)
+            // TODO: pass existingSite so client-only fields (sortKey, excludedApps, dnsOverride) survive re-enrollment
             siteDir = saveSite(context, json)
         } catch (err: Exception) {
             return result.error("unhandled_error", err.message, null)

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -192,16 +192,28 @@ class NebulaVpnService : VpnService() {
             disallowApp(builder, packageName)
         }
 
+        // A managed config can push a malformed resolver or search domain, which
+        // VpnService.Builder rejects by throwing. Skip the bad entry instead of
+        // unwinding out of startVpn, which would leave the UI on "connecting"
+        // forever with no exit announced.
         var hasDnsResolvers = false
         site!!.dnsResolvers.forEach {
-            hasDnsResolvers = true
-            builder.addDnsServer(it)
-            Log.i(TAG, "Adding dns resolver: $it")
+            try {
+                builder.addDnsServer(it)
+                hasDnsResolvers = true
+                Log.i(TAG, "Adding dns resolver: $it")
+            } catch (err: Exception) {
+                Log.w(TAG, "Skipping invalid dns resolver $it: ${err.message}")
+            }
         }
 
         site!!.searchDomains.forEach {
-            builder.addSearchDomain(it)
-            Log.i(TAG, "Adding dns search domain: $it")
+            try {
+                builder.addSearchDomain(it)
+                Log.i(TAG, "Adding dns search domain: $it")
+            } catch (err: Exception) {
+                Log.w(TAG, "Skipping invalid dns search domain $it: ${err.message}")
+            }
         }
 
         if (site!!.matchDomains.isNotEmpty()) {

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/NebulaVpnService.kt
@@ -199,6 +199,17 @@ class NebulaVpnService : VpnService() {
             Log.i(TAG, "Adding dns resolver: $it")
         }
 
+        site!!.searchDomains.forEach {
+            builder.addSearchDomain(it)
+            Log.i(TAG, "Adding dns search domain: $it")
+        }
+
+        if (site!!.matchDomains.isNotEmpty()) {
+            // VpnService cannot split DNS by domain, so the resolvers above
+            // receive queries for all domains, not just the match list.
+            Log.w(TAG, "Match domains are unsupported on Android; dns resolvers will serve all domains")
+        }
+
         if (isChromeOs() && !hasDnsResolvers) {
             // Newer versions of ChromeOS need a dns server installed for resolution to work at all.
             // Even if the system is configured to use DoH in which case the resolvers here will may be entirely ignored.

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -279,13 +279,13 @@ fun saveSite(context: Context, jsonString: String, existingSite: Site? = null): 
         if (!map.containsKey("excludedApps")) {
             map["excludedApps"] = existingSite.excludedApps
         }
-        if (!map.containsKey("dnsOverride") && existingSite.dnsOverrideRaw != null) {
-            map["dnsOverride"] = existingSite.dnsOverrideRaw
+        if (!map.containsKey("dnsOverride") && existingSite.dnsOverride != null) {
+            map["dnsOverride"] = existingSite.dnsOverride
         }
     }
 
     // Stamp the current config version
-    map["configVersion"] = 1
+    map["configVersion"] = 2
 
     // Write the remaining config to disk
     val confFile = siteDir.resolve("config.json")
@@ -320,10 +320,10 @@ class Site(context: Context, siteDir: File) {
     val matchDomains: List<String>
     val searchDomains: List<String>
 
-    // Device-local DNS override, kept raw so saveSite can preserve it across
-    // managed updates (client-only field, like excludedApps)
-    @Transient
-    val dnsOverrideRaw: Map<String, Any?>?
+    // Device-local DNS override (client-only field, like excludedApps);
+    // exported to Flutter for editing and preserved by saveSite across
+    // managed config updates
+    val dnsOverride: Map<String, Any?>?
 
     // Path to this site on disk
     @Transient
@@ -387,10 +387,10 @@ class Site(context: Context, siteDir: File) {
         } catch (_: Exception) { emptyList() }
 
         @Suppress("UNCHECKED_CAST")
-        dnsOverrideRaw = siteMap["dnsOverride"] as? Map<String, Any?>
+        dnsOverride = siteMap["dnsOverride"] as? Map<String, Any?>
 
         // Resolve effective DNS settings via the shared Go helper: device-local
-        // override, else managed definednet.dns, else manual mobile_nebula settings
+        // override, else managed definednet.dns
         var effectiveDNS: EffectiveDNS? = null
         try {
             effectiveDNS = gson.fromJson(mobileNebula.MobileNebula.effectiveDNS(config), EffectiveDNS::class.java)

--- a/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
+++ b/android/app/src/main/kotlin/net/defined/mobile_nebula/Sites.kt
@@ -212,11 +212,19 @@ data class UnsafeRoute(
     val mtu: Int?
 )
 
+// Result of mobileNebula.MobileNebula.effectiveDNS()
+data class EffectiveDNS(
+    val resolvers: List<String>,
+    val matchDomains: List<String>,
+    val searchDomains: List<String>,
+    val source: String
+)
+
 /**
  * Saves a site JSON string to disk. Extracts key and dnCredentials into
  * encrypted storage, handles the always-on file, and writes the remaining
  * config to config.json. Returns the site directory.
- * If existingSite is provided, client-only fields (sortKey, excludedApps) will be preserved from it.
+ * If existingSite is provided, client-only fields (sortKey, excludedApps, dnsOverride) will be preserved from it.
  */
 fun saveSite(context: Context, jsonString: String, existingSite: Site? = null): File {
     val gson = Gson()
@@ -271,6 +279,9 @@ fun saveSite(context: Context, jsonString: String, existingSite: Site? = null): 
         if (!map.containsKey("excludedApps")) {
             map["excludedApps"] = existingSite.excludedApps
         }
+        if (!map.containsKey("dnsOverride") && existingSite.dnsOverrideRaw != null) {
+            map["dnsOverride"] = existingSite.dnsOverrideRaw
+        }
     }
 
     // Stamp the current config version
@@ -306,6 +317,13 @@ class Site(context: Context, siteDir: File) {
     val mtu: Int
     val unsafeRoutes: List<UnsafeRoute>
     val dnsResolvers: List<String>
+    val matchDomains: List<String>
+    val searchDomains: List<String>
+
+    // Device-local DNS override, kept raw so saveSite can preserve it across
+    // managed updates (client-only field, like excludedApps)
+    @Transient
+    val dnsOverrideRaw: Map<String, Any?>?
 
     // Path to this site on disk
     @Transient
@@ -368,12 +386,20 @@ class Site(context: Context, siteDir: File) {
             } ?: emptyList()
         } catch (_: Exception) { emptyList() }
 
-        // Parse dnsResolvers from rawConfig
-        dnsResolvers = try {
-            val mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? Map<*, *>
-            val resolvers = mobileNebulaConfig?.get("dns_resolvers") as? List<*>
-            resolvers?.mapNotNull { it?.toString() } ?: emptyList()
-        } catch (_: Exception) { emptyList() }
+        @Suppress("UNCHECKED_CAST")
+        dnsOverrideRaw = siteMap["dnsOverride"] as? Map<String, Any?>
+
+        // Resolve effective DNS settings via the shared Go helper: device-local
+        // override, else managed definednet.dns, else manual mobile_nebula settings
+        var effectiveDNS: EffectiveDNS? = null
+        try {
+            effectiveDNS = gson.fromJson(mobileNebula.MobileNebula.effectiveDNS(config), EffectiveDNS::class.java)
+        } catch (err: Exception) {
+            errors.add("Failed to resolve DNS settings: ${err.message}")
+        }
+        dnsResolvers = effectiveDNS?.resolvers ?: emptyList()
+        matchDomains = effectiveDNS?.matchDomains ?: emptyList()
+        searchDomains = effectiveDNS?.searchDomains ?: emptyList()
 
         // Parse cert from rawConfig's pki.cert
         val pki = rawConfigMap["pki"] as? Map<*, *>

--- a/ios/NebulaNetworkExtension/ConfigMigrator.swift
+++ b/ios/NebulaNetworkExtension/ConfigMigrator.swift
@@ -18,6 +18,11 @@ enum ConfigMigrator {
       version = 1
     }
 
+    if version < 2 {
+      result = try migrateToV2(configData: result, path: path)
+      version = 2
+    }
+
     // Future migrations go here
 
     return result
@@ -38,6 +43,23 @@ enum ConfigMigrator {
     let oldJson = String(data: configData, encoding: .utf8) ?? "{}"
     var err: NSError?
     let newJson = MobileNebulaMigrateConfig(oldJson, key, &err)
+    if let err = err {
+      throw err
+    }
+
+    guard let newData = newJson.data(using: .utf8) else {
+      return configData
+    }
+
+    try newData.write(to: path)
+    return newData
+  }
+
+  /// Migrates from v1 to v2: mobile_nebula DNS settings move to the top-level dnsOverride field.
+  private static func migrateToV2(configData: Data, path: URL) throws -> Data {
+    let oldJson = String(data: configData, encoding: .utf8) ?? "{}"
+    var err: NSError?
+    let newJson = MobileNebulaMigrateConfigV2(oldJson, &err)
     if let err = err {
       throw err
     }

--- a/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
+++ b/ios/NebulaNetworkExtension/PacketTunnelProvider.swift
@@ -170,6 +170,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
       } else {
         dnsSettings.matchDomains = _site.matchDomains
       }
+      if !_site.searchDomains.isEmpty {
+        dnsSettings.searchDomains = _site.searchDomains
+      }
       tunnelNetworkSettings.dnsSettings = dnsSettings
     }
 

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -350,7 +350,8 @@ class Site: Encodable {
   var alwaysOn: Bool
   var errors: [String]
 
-  // Fields parsed from rawConfig for VPN service use (not encoded to Flutter)
+  // Fields parsed from rawConfig for VPN service use; the effective DNS
+  // fields are also encoded to Flutter for display
   var mtu: Int
   var unsafeRoutes: [UnsafeRoute]
   var dnsResolvers: [String]
@@ -661,6 +662,9 @@ class Site: Encodable {
     case alwaysOn
     case errors
     case dnsOverride
+    case dnsResolvers
+    case matchDomains
+    case searchDomains
   }
 }
 

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -159,7 +159,7 @@ class UnsafeRoute: Codable {
 
 /// Saves a site JSON string to disk. Extracts key and dnCredentials into
 /// encrypted storage and writes the remaining config to config.json.
-/// If existingSite is provided, client-only fields (sortKey) will be preserved from it.
+/// If existingSite is provided, client-only fields (sortKey, dnsOverride) will be preserved from it.
 func saveSiteToDisk(jsonString: String, existingSite: Site? = nil) throws {
   guard let jsonData = jsonString.data(using: .utf8),
     let obj = try? JSONSerialization.jsonObject(with: jsonData),
@@ -200,6 +200,9 @@ func saveSiteToDisk(jsonString: String, existingSite: Site? = nil) throws {
   if let existingSite = existingSite {
     if map["sortKey"] == nil {
       map["sortKey"] = existingSite.sortKey
+    }
+    if map["dnsOverride"] == nil, let dnsOverride = existingSite.dnsOverrideRaw {
+      map["dnsOverride"] = dnsOverride
     }
   }
 
@@ -334,6 +337,11 @@ class Site: Encodable {
   var unsafeRoutes: [UnsafeRoute]
   var dnsResolvers: [String]
   var matchDomains: [String]
+  var searchDomains: [String]
+
+  // Device-local DNS override, kept raw so saveSiteToDisk can preserve it
+  // across managed updates (client-only field, like sortKey)
+  var dnsOverrideRaw: [String: Any]?
 
   /// If true then this site needs to be migrated to the filesystem. Should be handled by the initiator of the site
   var needsToMigrateToFS: Bool = false
@@ -448,18 +456,25 @@ class Site: Encodable {
       unsafeRoutes = []
     }
 
-    // Parse dnsResolvers from rawConfig
-    let mobileNebulaConfig = rawConfigMap["mobile_nebula"] as? [String: Any]
-    if let resolvers = mobileNebulaConfig?["dns_resolvers"] as? [String] {
-      dnsResolvers = resolvers
-    } else {
-      dnsResolvers = []
-    }
+    dnsOverrideRaw = configMap["dnsOverride"] as? [String: Any]
 
-    if let domains = mobileNebulaConfig?["match_domains"] as? [String] {
-      matchDomains = domains
+    // Resolve effective DNS settings via the shared Go helper: device-local
+    // override, else managed definednet.dns, else manual mobile_nebula settings
+    var dnsErr: NSError?
+    let effectiveDNS = MobileNebulaEffectiveDNS(String(data: configData, encoding: .utf8), &dnsErr)
+    if dnsErr == nil,
+      let dnsData = effectiveDNS.data(using: .utf8),
+      let dns = try? JSONSerialization.jsonObject(with: dnsData) as? [String: Any]
+    {
+      dnsResolvers = dns["resolvers"] as? [String] ?? []
+      matchDomains = dns["matchDomains"] as? [String] ?? []
+      searchDomains = dns["searchDomains"] as? [String] ?? []
     } else {
+      errors.append(
+        "Failed to resolve DNS settings: \(dnsErr?.localizedDescription ?? "unknown error")")
+      dnsResolvers = []
       matchDomains = []
+      searchDomains = []
     }
 
     // Parse cert from rawConfig's pki.cert

--- a/ios/NebulaNetworkExtension/Site.swift
+++ b/ios/NebulaNetworkExtension/Site.swift
@@ -157,6 +157,24 @@ class UnsafeRoute: Codable {
   }
 }
 
+/// Device-local DNS override; typed so it can ride along in Site's Encodable
+/// output to Flutter.
+struct DNSOverride: Codable {
+  var enabled: Bool
+  var resolvers: [String]
+  var matchDomains: [String]
+  var searchDomains: [String]
+
+  func toDictionary() -> [String: Any] {
+    return [
+      "enabled": enabled,
+      "resolvers": resolvers,
+      "matchDomains": matchDomains,
+      "searchDomains": searchDomains,
+    ]
+  }
+}
+
 /// Saves a site JSON string to disk. Extracts key and dnCredentials into
 /// encrypted storage and writes the remaining config to config.json.
 /// If existingSite is provided, client-only fields (sortKey, dnsOverride) will be preserved from it.
@@ -201,13 +219,13 @@ func saveSiteToDisk(jsonString: String, existingSite: Site? = nil) throws {
     if map["sortKey"] == nil {
       map["sortKey"] = existingSite.sortKey
     }
-    if map["dnsOverride"] == nil, let dnsOverride = existingSite.dnsOverrideRaw {
-      map["dnsOverride"] = dnsOverride
+    if map["dnsOverride"] == nil, let dnsOverride = existingSite.dnsOverride {
+      map["dnsOverride"] = dnsOverride.toDictionary()
     }
   }
 
   // Stamp the current config version
-  map["configVersion"] = 1
+  map["configVersion"] = 2
 
   // Write the remaining config to disk
   let configPath = try SiteList.getSiteConfigFile(id: id, createDir: true)
@@ -339,9 +357,10 @@ class Site: Encodable {
   var matchDomains: [String]
   var searchDomains: [String]
 
-  // Device-local DNS override, kept raw so saveSiteToDisk can preserve it
-  // across managed updates (client-only field, like sortKey)
-  var dnsOverrideRaw: [String: Any]?
+  // Device-local DNS override (client-only field, like sortKey); exported to
+  // Flutter for editing and preserved by saveSiteToDisk across managed
+  // config updates
+  var dnsOverride: DNSOverride?
 
   /// If true then this site needs to be migrated to the filesystem. Should be handled by the initiator of the site
   var needsToMigrateToFS: Bool = false
@@ -456,10 +475,18 @@ class Site: Encodable {
       unsafeRoutes = []
     }
 
-    dnsOverrideRaw = configMap["dnsOverride"] as? [String: Any]
+    if let override = configMap["dnsOverride"] as? [String: Any] {
+      dnsOverride = DNSOverride(
+        enabled: override["enabled"] as? Bool ?? false,
+        resolvers: override["resolvers"] as? [String] ?? [],
+        matchDomains: override["matchDomains"] as? [String] ?? [],
+        searchDomains: override["searchDomains"] as? [String] ?? [])
+    } else {
+      dnsOverride = nil
+    }
 
     // Resolve effective DNS settings via the shared Go helper: device-local
-    // override, else managed definednet.dns, else manual mobile_nebula settings
+    // override, else managed definednet.dns
     var dnsErr: NSError?
     let effectiveDNS = MobileNebulaEffectiveDNS(String(data: configData, encoding: .utf8), &dnsErr)
     if dnsErr == nil,
@@ -633,6 +660,7 @@ class Site: Encodable {
     case logFile
     case alwaysOn
     case errors
+    case dnsOverride
   }
 }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -162,6 +162,7 @@ func MissingArgumentError(message: String, details: Any?) -> FlutterError {
       }
 
       let oldSite = self.sites?.getSite(id: id)
+      // TODO: pass existingSite so client-only fields (sortKey, dnsOverride) survive re-enrollment
       saveSite(jsonString: json, manager: oldSite?.manager) { error in
         if error != nil {
           return result(

--- a/lib/models/site.dart
+++ b/lib/models/site.dart
@@ -47,6 +47,9 @@ class Site {
   late bool alwaysOn;
   late List<String> excludedApps;
 
+  // Device-local DNS override (client-only field, preserved across managed config updates)
+  Map<String, dynamic>? dnsOverride;
+
   // DN management
   late bool managed;
   late DateTime? lastManagedUpdate;
@@ -70,6 +73,7 @@ class Site {
     this.lastManagedUpdate,
     this.alwaysOn = false,
     List<String>? excludedApps,
+    this.dnsOverride,
   }) {
     this.id = id ?? uuid.v4();
     this.rawConfig = rawConfig ?? {};
@@ -119,6 +123,7 @@ class Site {
       lastManagedUpdate: decoded['lastManagedUpdate'],
       alwaysOn: decoded['alwaysOn'],
       excludedApps: decoded['excludedApps'],
+      dnsOverride: decoded['dnsOverride'],
     );
   }
 
@@ -206,6 +211,7 @@ class Site {
     lastManagedUpdate = decoded['lastManagedUpdate'];
     alwaysOn = decoded['alwaysOn'];
     excludedApps = decoded['excludedApps'];
+    dnsOverride = decoded['dnsOverride'];
   }
 
   static Map<String, dynamic> _fromJson(Map<String, dynamic> json) {
@@ -259,6 +265,7 @@ class Site {
       "lastManagedUpdate": json["lastManagedUpdate"] == null ? null : DateTime.parse(json["lastManagedUpdate"]),
       "alwaysOn": json['alwaysOn'] ?? false,
       "excludedApps": excludedApps,
+      "dnsOverride": json['dnsOverride'] == null ? null : Map<String, dynamic>.from(json['dnsOverride']),
     };
   }
 
@@ -267,7 +274,7 @@ class Site {
   }
 
   Map<String, dynamic> toJson() {
-    return {
+    final json = <String, dynamic>{
       'name': name,
       'id': id,
       'sortKey': sortKey,
@@ -278,6 +285,11 @@ class Site {
       'alwaysOn': alwaysOn,
       'excludedApps': excludedApps,
     };
+    // Omitted when unset so the platform save path preserves any existing override
+    if (dnsOverride != null) {
+      json['dnsOverride'] = dnsOverride;
+    }
+    return json;
   }
 
   // Convenience getters for UI — read from rawConfig
@@ -313,11 +325,9 @@ class Site {
     return routes.map((r) => UnsafeRoute.fromJson(Map<String, dynamic>.from(r))).toList();
   }
 
-  List<String> get dnsResolvers {
-    final resolvers = _getConfig<List<dynamic>>(['mobile_nebula', 'dns_resolvers']);
-    if (resolvers == null) return [];
-    return resolvers.map((r) => r.toString()).toList();
-  }
+  // DNS settings read and write the device-local dnsOverride; managed DNS in
+  // rawConfig applies only while the override is not enabled
+  List<String> get dnsResolvers => _dnsOverrideList('resolvers');
 
   Map<String, StaticHost> get staticHostmap {
     final shm = _getConfig<Map<String, dynamic>>(['static_host_map']) ?? {};
@@ -355,18 +365,24 @@ class Site {
     _setConfig(['tun', 'unsafe_routes'], routes.map((r) => r.toJson()).toList());
   }
 
-  set dnsResolvers(List<String> resolvers) {
-    _setConfig(['mobile_nebula', 'dns_resolvers'], resolvers);
+  set dnsResolvers(List<String> resolvers) => _setDnsOverride('resolvers', resolvers);
+
+  List<String> get matchDomains => _dnsOverrideList('matchDomains');
+
+  set matchDomains(List<String> domains) => _setDnsOverride('matchDomains', domains);
+
+  List<String> _dnsOverrideList(String key) {
+    final values = dnsOverride?[key];
+    if (values is! List) return [];
+    return values.map((v) => v.toString()).toList();
   }
 
-  List<String> get matchDomains {
-    final domains = _getConfig<List<dynamic>>(['mobile_nebula', 'match_domains']);
-    if (domains == null) return [];
-    return domains.map((d) => d.toString()).toList();
-  }
-
-  set matchDomains(List<String> domains) {
-    _setConfig(['mobile_nebula', 'match_domains'], domains);
+  // Writing any DNS setting enables the override so the values take effect on save
+  void _setDnsOverride(String key, List<String> values) {
+    final override = dnsOverride ?? <String, dynamic>{};
+    override[key] = values;
+    override['enabled'] = true;
+    dnsOverride = override;
   }
 
   List<FirewallRule> get inboundFirewallRules {

--- a/lib/models/site.dart
+++ b/lib/models/site.dart
@@ -144,6 +144,33 @@ class Site {
       pki.remove('key');
     }
 
+    // Hoist legacy mobile_nebula DNS settings into dnsOverride, mirroring the
+    // configVersion 2 migration; imported YAML never passes through ConfigMigrator
+    Map<String, dynamic>? dnsOverride;
+    if (rawConfig['mobile_nebula'] is Map<String, dynamic>) {
+      final mobileNebula = rawConfig['mobile_nebula'] as Map<String, dynamic>;
+      List<String> takeStringList(String key) {
+        final values = mobileNebula.remove(key);
+        if (values is! List) return [];
+        return values.map((v) => v.toString()).where((v) => v.isNotEmpty).toList();
+      }
+
+      final resolvers = takeStringList('dns_resolvers');
+      final matchDomains = takeStringList('match_domains');
+      final searchDomains = takeStringList('search_domains');
+      if (resolvers.isNotEmpty || matchDomains.isNotEmpty || searchDomains.isNotEmpty) {
+        dnsOverride = {
+          'enabled': true,
+          'resolvers': resolvers,
+          'matchDomains': matchDomains,
+          'searchDomains': searchDomains,
+        };
+      }
+      if (mobileNebula.isEmpty) {
+        rawConfig.remove('mobile_nebula');
+      }
+    }
+
     // Parse certs for display via native
     List<CertificateInfo> ca = [];
     CertificateInfo? certInfo;
@@ -191,7 +218,7 @@ class Site {
       }
     }
 
-    return Site(rawConfig: rawConfig, ca: ca, certInfo: certInfo, errors: errors)..key = key;
+    return Site(rawConfig: rawConfig, ca: ca, certInfo: certInfo, errors: errors, dnsOverride: dnsOverride)..key = key;
   }
 
   void _updateFromJson(String json) {

--- a/lib/models/site.dart
+++ b/lib/models/site.dart
@@ -50,6 +50,11 @@ class Site {
   // Device-local DNS override (client-only field, preserved across managed config updates)
   Map<String, dynamic>? dnsOverride;
 
+  // Effective DNS as resolved by the platform (dnsOverride when enabled, else
+  // managed definednet.dns). Display-only; edits go through the dnsOverride setters.
+  late List<String> effectiveDnsResolvers;
+  late List<String> effectiveMatchDomains;
+
   // DN management
   late bool managed;
   late DateTime? lastManagedUpdate;
@@ -74,12 +79,16 @@ class Site {
     this.alwaysOn = false,
     List<String>? excludedApps,
     this.dnsOverride,
+    List<String>? effectiveDnsResolvers,
+    List<String>? effectiveMatchDomains,
   }) {
     this.id = id ?? uuid.v4();
     this.rawConfig = rawConfig ?? {};
     this.ca = ca ?? [];
     this.errors = errors ?? [];
     this.excludedApps = excludedApps ?? [];
+    this.effectiveDnsResolvers = effectiveDnsResolvers ?? [];
+    this.effectiveMatchDomains = effectiveMatchDomains ?? [];
 
     if (id != null) {
       _updates = EventChannel('net.defined.nebula/${this.id}');
@@ -124,6 +133,8 @@ class Site {
       alwaysOn: decoded['alwaysOn'],
       excludedApps: decoded['excludedApps'],
       dnsOverride: decoded['dnsOverride'],
+      effectiveDnsResolvers: decoded['effectiveDnsResolvers'],
+      effectiveMatchDomains: decoded['effectiveMatchDomains'],
     );
   }
 
@@ -239,6 +250,8 @@ class Site {
     alwaysOn = decoded['alwaysOn'];
     excludedApps = decoded['excludedApps'];
     dnsOverride = decoded['dnsOverride'];
+    effectiveDnsResolvers = decoded['effectiveDnsResolvers'];
+    effectiveMatchDomains = decoded['effectiveMatchDomains'];
   }
 
   static Map<String, dynamic> _fromJson(Map<String, dynamic> json) {
@@ -253,11 +266,12 @@ class Site {
       }
     }
 
-    List<dynamic> rawExcludedApps = json['excludedApps'] ?? [];
-    List<String> excludedApps = [];
-    for (var val in rawExcludedApps) {
-      excludedApps.add(val.toString());
+    List<String> stringList(dynamic values) {
+      if (values is! List) return [];
+      return values.map((v) => v.toString()).toList();
     }
+
+    List<String> excludedApps = stringList(json['excludedApps']);
 
     List<dynamic> rawCA = json['ca'] ?? [];
     List<CertificateInfo> ca = [];
@@ -293,6 +307,10 @@ class Site {
       "alwaysOn": json['alwaysOn'] ?? false,
       "excludedApps": excludedApps,
       "dnsOverride": json['dnsOverride'] == null ? null : Map<String, dynamic>.from(json['dnsOverride']),
+      // Effective DNS resolved by the platform (keyed dnsResolvers/matchDomains
+      // in the platform Site serialization)
+      "effectiveDnsResolvers": stringList(json['dnsResolvers']),
+      "effectiveMatchDomains": stringList(json['matchDomains']),
     };
   }
 
@@ -404,8 +422,12 @@ class Site {
     return values.map((v) => v.toString()).toList();
   }
 
-  // Writing any DNS setting enables the override so the values take effect on save
+  // Writing any DNS setting enables the override so the values take effect on
+  // save. Empty values with no existing override are dropped: an enabled-empty
+  // override deliberately disables managed DNS, and the Advanced screen save
+  // path writes these setters unconditionally (seeded empty on managed sites).
   void _setDnsOverride(String key, List<String> values) {
+    if (dnsOverride == null && values.isEmpty) return;
     final override = dnsOverride ?? <String, dynamic>{};
     override[key] = values;
     override['enabled'] = true;

--- a/lib/screens/siteConfig/advanced_screen.dart
+++ b/lib/screens/siteConfig/advanced_screen.dart
@@ -84,6 +84,12 @@ class AdvancedScreenState extends State<AdvancedScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Managed sites show the effective DNS resolved by the platform (read-only);
+    // settings holds only the device-local override, which seeds empty when the
+    // managed definednet.dns config is in effect
+    final dnsResolvers = widget.site.managed ? widget.site.effectiveDnsResolvers : settings.dnsResolvers;
+    final matchDomains = widget.site.managed ? widget.site.effectiveMatchDomains : settings.matchDomains;
+
     return FormPage(
       title: 'Advanced Settings',
       changed: changed,
@@ -219,12 +225,12 @@ class AdvancedScreenState extends State<AdvancedScreen> {
               ConfigPageItem(
                 label: Text('DNS resolvers'),
                 labelWidth: 150,
-                content: Text(Utils.itemCountFormat(settings.dnsResolvers.length), textAlign: TextAlign.end),
+                content: Text(Utils.itemCountFormat(dnsResolvers.length), textAlign: TextAlign.end),
                 onPressed: () {
                   Utils.openPage(context, (context) {
                     return DnsResolversScreen(
-                      dnsResolvers: settings.dnsResolvers,
-                      matchDomains: settings.matchDomains,
+                      dnsResolvers: dnsResolvers,
+                      matchDomains: matchDomains,
                       onSave: widget.site.managed
                           ? null
                           : (resolvers) {

--- a/nebula/dns.go
+++ b/nebula/dns.go
@@ -11,7 +11,7 @@ type effectiveDNS struct {
 	Resolvers     []string `json:"resolvers"`
 	MatchDomains  []string `json:"matchDomains"`
 	SearchDomains []string `json:"searchDomains"`
-	// Source records which channel won: "override", "managed", or "manual".
+	// Source records which channel won: "override", "managed", or "none".
 	Source string `json:"source"`
 }
 
@@ -29,8 +29,8 @@ type dnsOverride struct {
 // EffectiveDNS resolves the DNS settings a platform should apply for a site
 // from its site JSON. Precedence: the device-local dnsOverride when enabled,
 // else the managed definednet.dns block from rawConfig (non-empty
-// resolver_addrs is the install signal, matching dnclient), else the manual
-// mobile_nebula settings from rawConfig. Returns a JSON object:
+// resolver_addrs is the install signal, matching dnclient). Returns a JSON
+// object:
 //
 //	{"resolvers": [...], "matchDomains": [...], "searchDomains": [...], "source": "..."}
 func EffectiveDNS(siteJSON string) (string, error) {
@@ -49,7 +49,7 @@ func EffectiveDNS(siteJSON string) (string, error) {
 		}
 	}
 
-	result := effectiveDNS{Source: "manual"}
+	result := effectiveDNS{Source: "none"}
 
 	if s.DNSOverride != nil && s.DNSOverride.Enabled {
 		// Enabled with empty resolvers deliberately disables DNS on this device.
@@ -62,28 +62,26 @@ func EffectiveDNS(siteJSON string) (string, error) {
 		result.Resolvers = stringList(dns, "resolver_addrs")
 		result.MatchDomains = stringList(dns, "match_domains")
 		result.SearchDomains = stringList(dns, "search_domains")
-	} else if mn := getMap(rawConfig, "mobile_nebula"); mn != nil {
-		result.Resolvers = stringList(mn, "dns_resolvers")
-		result.MatchDomains = stringList(mn, "match_domains")
-		result.SearchDomains = stringList(mn, "search_domains")
 	}
 
 	// Marshal empty lists as [] rather than null for the platform parsers
-	if result.Resolvers == nil {
-		result.Resolvers = []string{}
-	}
-	if result.MatchDomains == nil {
-		result.MatchDomains = []string{}
-	}
-	if result.SearchDomains == nil {
-		result.SearchDomains = []string{}
-	}
+	result.Resolvers = orEmpty(result.Resolvers)
+	result.MatchDomains = orEmpty(result.MatchDomains)
+	result.SearchDomains = orEmpty(result.SearchDomains)
 
 	out, err := json.Marshal(result)
 	if err != nil {
 		return "", err
 	}
 	return string(out), nil
+}
+
+// orEmpty replaces a nil list with an empty one.
+func orEmpty(l []string) []string {
+	if l == nil {
+		return []string{}
+	}
+	return l
 }
 
 // getMap walks nested map keys, returning nil if any step is missing or not a map.

--- a/nebula/dns.go
+++ b/nebula/dns.go
@@ -57,11 +57,14 @@ func EffectiveDNS(siteJSON string) (string, error) {
 		result.Resolvers = s.DNSOverride.Resolvers
 		result.MatchDomains = s.DNSOverride.MatchDomains
 		result.SearchDomains = s.DNSOverride.SearchDomains
-	} else if dns := getMap(rawConfig, "definednet", "dns"); len(stringList(dns, "resolver_addrs")) > 0 {
-		result.Source = "managed"
-		result.Resolvers = stringList(dns, "resolver_addrs")
-		result.MatchDomains = stringList(dns, "match_domains")
-		result.SearchDomains = stringList(dns, "search_domains")
+	} else {
+		dns := getMap(rawConfig, "definednet", "dns")
+		if resolvers := stringList(dns, "resolver_addrs"); len(resolvers) > 0 {
+			result.Source = "managed"
+			result.Resolvers = resolvers
+			result.MatchDomains = stringList(dns, "match_domains")
+			result.SearchDomains = stringList(dns, "search_domains")
+		}
 	}
 
 	// Marshal empty lists as [] rather than null for the platform parsers

--- a/nebula/dns.go
+++ b/nebula/dns.go
@@ -1,0 +1,121 @@
+package mobileNebula
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// effectiveDNS is the DNS configuration a platform layer should apply for a
+// site. An empty Resolvers list means DNS should not be configured.
+type effectiveDNS struct {
+	Resolvers     []string `json:"resolvers"`
+	MatchDomains  []string `json:"matchDomains"`
+	SearchDomains []string `json:"searchDomains"`
+	// Source records which channel won: "override", "managed", or "manual".
+	Source string `json:"source"`
+}
+
+// dnsOverride is the device-local DNS override, stored as a client-only
+// top-level site field so it survives managed config updates. The explicit
+// Enabled flag (rather than non-empty resolvers as the signal) lets a user
+// disable managed DNS on this device without substituting their own resolvers.
+type dnsOverride struct {
+	Enabled       bool     `json:"enabled"`
+	Resolvers     []string `json:"resolvers"`
+	MatchDomains  []string `json:"matchDomains"`
+	SearchDomains []string `json:"searchDomains"`
+}
+
+// EffectiveDNS resolves the DNS settings a platform should apply for a site
+// from its site JSON. Precedence: the device-local dnsOverride when enabled,
+// else the managed definednet.dns block from rawConfig (non-empty
+// resolver_addrs is the install signal, matching dnclient), else the manual
+// mobile_nebula settings from rawConfig. Returns a JSON object:
+//
+//	{"resolvers": [...], "matchDomains": [...], "searchDomains": [...], "source": "..."}
+func EffectiveDNS(siteJSON string) (string, error) {
+	var s struct {
+		RawConfig   string       `json:"rawConfig"`
+		DNSOverride *dnsOverride `json:"dnsOverride"`
+	}
+	if err := json.Unmarshal([]byte(siteJSON), &s); err != nil {
+		return "", fmt.Errorf("failed to parse site JSON: %s", err)
+	}
+
+	var rawConfig map[string]any
+	if s.RawConfig != "" {
+		if err := json.Unmarshal([]byte(s.RawConfig), &rawConfig); err != nil {
+			return "", fmt.Errorf("failed to parse rawConfig: %s", err)
+		}
+	}
+
+	result := effectiveDNS{Source: "manual"}
+
+	if s.DNSOverride != nil && s.DNSOverride.Enabled {
+		// Enabled with empty resolvers deliberately disables DNS on this device.
+		result.Source = "override"
+		result.Resolvers = s.DNSOverride.Resolvers
+		result.MatchDomains = s.DNSOverride.MatchDomains
+		result.SearchDomains = s.DNSOverride.SearchDomains
+	} else if dns := getMap(rawConfig, "definednet", "dns"); len(stringList(dns, "resolver_addrs")) > 0 {
+		result.Source = "managed"
+		result.Resolvers = stringList(dns, "resolver_addrs")
+		result.MatchDomains = stringList(dns, "match_domains")
+		result.SearchDomains = stringList(dns, "search_domains")
+	} else if mn := getMap(rawConfig, "mobile_nebula"); mn != nil {
+		result.Resolvers = stringList(mn, "dns_resolvers")
+		result.MatchDomains = stringList(mn, "match_domains")
+		result.SearchDomains = stringList(mn, "search_domains")
+	}
+
+	// Marshal empty lists as [] rather than null for the platform parsers
+	if result.Resolvers == nil {
+		result.Resolvers = []string{}
+	}
+	if result.MatchDomains == nil {
+		result.MatchDomains = []string{}
+	}
+	if result.SearchDomains == nil {
+		result.SearchDomains = []string{}
+	}
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// getMap walks nested map keys, returning nil if any step is missing or not a map.
+func getMap(m map[string]any, path ...string) map[string]any {
+	cur := m
+	for _, k := range path {
+		next, ok := cur[k].(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = next
+	}
+	return cur
+}
+
+// stringList reads a list of strings at key, dropping non-string and empty entries.
+func stringList(m map[string]any, key string) []string {
+	if m == nil {
+		return nil
+	}
+	raw, ok := m[key].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/nebula/dns.go
+++ b/nebula/dns.go
@@ -42,13 +42,6 @@ func EffectiveDNS(siteJSON string) (string, error) {
 		return "", fmt.Errorf("failed to parse site JSON: %s", err)
 	}
 
-	var rawConfig map[string]any
-	if s.RawConfig != "" {
-		if err := json.Unmarshal([]byte(s.RawConfig), &rawConfig); err != nil {
-			return "", fmt.Errorf("failed to parse rawConfig: %s", err)
-		}
-	}
-
 	result := effectiveDNS{Source: "none"}
 
 	if s.DNSOverride != nil && s.DNSOverride.Enabled {
@@ -58,6 +51,13 @@ func EffectiveDNS(siteJSON string) (string, error) {
 		result.MatchDomains = s.DNSOverride.MatchDomains
 		result.SearchDomains = s.DNSOverride.SearchDomains
 	} else {
+		// An unparsable rawConfig holds no readable managed DNS, and the site
+		// loaders already surface the parse failure. Resolving to no DNS keeps a
+		// usable override from being discarded alongside it, matching the
+		// tolerance MigrateConfigV2 has for the same input.
+		var rawConfig map[string]any
+		_ = json.Unmarshal([]byte(s.RawConfig), &rawConfig)
+
 		dns := getMap(rawConfig, "definednet", "dns")
 		if resolvers := stringList(dns, "resolver_addrs"); len(resolvers) > 0 {
 			result.Source = "managed"

--- a/nebula/dns_test.go
+++ b/nebula/dns_test.go
@@ -269,7 +269,27 @@ func TestMigrateConfigV2_MissingRawConfig(t *testing.T) {
 func TestMigrateConfigV2_InvalidJSON(t *testing.T) {
 	_, err := MigrateConfigV2(`not json`)
 	assert.Error(t, err)
+}
 
-	_, err = MigrateConfigV2(`{"rawConfig": "not json"}`)
-	assert.Error(t, err)
+func TestMigrateConfigV2_UnparsableRawConfigStillMigrates(t *testing.T) {
+	// A migration error gets the site deleted as non-conforming by the platform
+	// loaders; an unparsable rawConfig must instead pass through untouched so
+	// the site loads and surfaces a parse error
+	siteMap := migrateV2(t, `{"rawConfig": "not json"}`)
+	assert.Equal(t, float64(2), siteMap["configVersion"])
+	assert.Equal(t, "not json", siteMap["rawConfig"])
+}
+
+func TestMigrateConfigV2_NullOverrideStillHoists(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"mobile_nebula": map[string]any{
+			"dns_resolvers": []string{"1.1.1.1"},
+		},
+	}, map[string]any{"dnsOverride": nil})
+
+	siteMap := migrateV2(t, s)
+	override, ok := siteMap["dnsOverride"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"1.1.1.1"}, override["resolvers"])
+	assert.NotContains(t, rawConfigOf(t, siteMap), "mobile_nebula")
 }

--- a/nebula/dns_test.go
+++ b/nebula/dns_test.go
@@ -1,0 +1,175 @@
+package mobileNebula
+
+import (
+	"encoding/json"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func effectiveDNSFromJSON(t *testing.T, siteJSON string) effectiveDNS {
+	t.Helper()
+	out, err := EffectiveDNS(siteJSON)
+	require.NoError(t, err)
+	var result effectiveDNS
+	require.NoError(t, json.Unmarshal([]byte(out), &result))
+	return result
+}
+
+func siteJSON(t *testing.T, rawConfig map[string]any, extra map[string]any) string {
+	t.Helper()
+	rawBytes, err := json.Marshal(rawConfig)
+	require.NoError(t, err)
+	site := map[string]any{"rawConfig": string(rawBytes)}
+	maps.Copy(site, extra)
+	siteBytes, err := json.Marshal(site)
+	require.NoError(t, err)
+	return string(siteBytes)
+}
+
+func TestEffectiveDNS_Managed(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"definednet": map[string]any{
+			"dns": map[string]any{
+				"resolver_addrs": []string{"240.0.0.1", "240.0.0.2"},
+				"match_domains":  []string{"internal.example.com"},
+				"search_domains": []string{"example.com"},
+			},
+		},
+	}, nil)
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "managed", result.Source)
+	assert.Equal(t, []string{"240.0.0.1", "240.0.0.2"}, result.Resolvers)
+	assert.Equal(t, []string{"internal.example.com"}, result.MatchDomains)
+	assert.Equal(t, []string{"example.com"}, result.SearchDomains)
+}
+
+func TestEffectiveDNS_ManagedWinsOverManual(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"definednet": map[string]any{
+			"dns": map[string]any{
+				"resolver_addrs": []string{"240.0.0.1"},
+			},
+		},
+		"mobile_nebula": map[string]any{
+			"dns_resolvers": []string{"1.1.1.1"},
+		},
+	}, nil)
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "managed", result.Source)
+	assert.Equal(t, []string{"240.0.0.1"}, result.Resolvers)
+}
+
+func TestEffectiveDNS_EmptyManagedFallsBackToManual(t *testing.T) {
+	// resolver_addrs is the install signal; empty means the managed channel is inert
+	s := siteJSON(t, map[string]any{
+		"definednet": map[string]any{
+			"dns": map[string]any{
+				"resolver_addrs": []string{},
+				"match_domains":  []string{"ignored.example.com"},
+			},
+		},
+		"mobile_nebula": map[string]any{
+			"dns_resolvers": []string{"1.1.1.1"},
+			"match_domains": []string{"internal.example.com"},
+		},
+	}, nil)
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "manual", result.Source)
+	assert.Equal(t, []string{"1.1.1.1"}, result.Resolvers)
+	assert.Equal(t, []string{"internal.example.com"}, result.MatchDomains)
+}
+
+func TestEffectiveDNS_OverrideWinsOverManaged(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"definednet": map[string]any{
+			"dns": map[string]any{
+				"resolver_addrs": []string{"240.0.0.1"},
+			},
+		},
+	}, map[string]any{
+		"dnsOverride": map[string]any{
+			"enabled":       true,
+			"resolvers":     []string{"192.168.1.53"},
+			"searchDomains": []string{"home.example.com"},
+		},
+	})
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "override", result.Source)
+	assert.Equal(t, []string{"192.168.1.53"}, result.Resolvers)
+	assert.Equal(t, []string{"home.example.com"}, result.SearchDomains)
+}
+
+func TestEffectiveDNS_OverrideEnabledEmptyDisablesDNS(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"definednet": map[string]any{
+			"dns": map[string]any{
+				"resolver_addrs": []string{"240.0.0.1"},
+			},
+		},
+	}, map[string]any{
+		"dnsOverride": map[string]any{
+			"enabled":   true,
+			"resolvers": []string{},
+		},
+	})
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "override", result.Source)
+	assert.Empty(t, result.Resolvers)
+}
+
+func TestEffectiveDNS_DisabledOverrideIsIgnored(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"definednet": map[string]any{
+			"dns": map[string]any{
+				"resolver_addrs": []string{"240.0.0.1"},
+			},
+		},
+	}, map[string]any{
+		"dnsOverride": map[string]any{
+			"enabled":   false,
+			"resolvers": []string{"192.168.1.53"},
+		},
+	})
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "managed", result.Source)
+	assert.Equal(t, []string{"240.0.0.1"}, result.Resolvers)
+}
+
+func TestEffectiveDNS_NoDNSAnywhere(t *testing.T) {
+	s := siteJSON(t, map[string]any{}, nil)
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "manual", result.Source)
+	assert.Empty(t, result.Resolvers)
+	assert.Empty(t, result.MatchDomains)
+	assert.Empty(t, result.SearchDomains)
+}
+
+func TestEffectiveDNS_EmptyListsMarshalAsArrays(t *testing.T) {
+	out, err := EffectiveDNS(`{"rawConfig": "{}"}`)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"resolvers": [], "matchDomains": [], "searchDomains": [], "source": "manual"}`, out)
+}
+
+func TestEffectiveDNS_MissingRawConfig(t *testing.T) {
+	result := effectiveDNSFromJSON(t, `{}`)
+	assert.Equal(t, "manual", result.Source)
+	assert.Empty(t, result.Resolvers)
+}
+
+func TestEffectiveDNS_InvalidJSON(t *testing.T) {
+	_, err := EffectiveDNS(`not json`)
+	assert.Error(t, err)
+
+	_, err = EffectiveDNS(`{"rawConfig": "not json"}`)
+	assert.Error(t, err)
+}

--- a/nebula/dns_test.go
+++ b/nebula/dns_test.go
@@ -164,9 +164,20 @@ func TestEffectiveDNS_MissingRawConfig(t *testing.T) {
 func TestEffectiveDNS_InvalidJSON(t *testing.T) {
 	_, err := EffectiveDNS(`not json`)
 	assert.Error(t, err)
+}
 
-	_, err = EffectiveDNS(`{"rawConfig": "not json"}`)
-	assert.Error(t, err)
+func TestEffectiveDNS_UnparsableRawConfigYieldsNoManagedDNS(t *testing.T) {
+	result := effectiveDNSFromJSON(t, `{"rawConfig": "not json"}`)
+	assert.Equal(t, "none", result.Source)
+	assert.Empty(t, result.Resolvers)
+}
+
+func TestEffectiveDNS_UnparsableRawConfigKeepsOverride(t *testing.T) {
+	// The site loaders report the rawConfig parse failure on their own; losing
+	// the override here would report it twice and throw away usable settings
+	result := effectiveDNSFromJSON(t, `{"rawConfig": "not json", "dnsOverride": {"enabled": true, "resolvers": ["10.1.1.1"]}}`)
+	assert.Equal(t, "override", result.Source)
+	assert.Equal(t, []string{"10.1.1.1"}, result.Resolvers)
 }
 
 func migrateV2(t *testing.T, siteJSON string) map[string]any {

--- a/nebula/dns_test.go
+++ b/nebula/dns_test.go
@@ -47,24 +47,7 @@ func TestEffectiveDNS_Managed(t *testing.T) {
 	assert.Equal(t, []string{"example.com"}, result.SearchDomains)
 }
 
-func TestEffectiveDNS_ManagedWinsOverManual(t *testing.T) {
-	s := siteJSON(t, map[string]any{
-		"definednet": map[string]any{
-			"dns": map[string]any{
-				"resolver_addrs": []string{"240.0.0.1"},
-			},
-		},
-		"mobile_nebula": map[string]any{
-			"dns_resolvers": []string{"1.1.1.1"},
-		},
-	}, nil)
-
-	result := effectiveDNSFromJSON(t, s)
-	assert.Equal(t, "managed", result.Source)
-	assert.Equal(t, []string{"240.0.0.1"}, result.Resolvers)
-}
-
-func TestEffectiveDNS_EmptyManagedFallsBackToManual(t *testing.T) {
+func TestEffectiveDNS_EmptyManagedIsInert(t *testing.T) {
 	// resolver_addrs is the install signal; empty means the managed channel is inert
 	s := siteJSON(t, map[string]any{
 		"definednet": map[string]any{
@@ -73,6 +56,18 @@ func TestEffectiveDNS_EmptyManagedFallsBackToManual(t *testing.T) {
 				"match_domains":  []string{"ignored.example.com"},
 			},
 		},
+	}, nil)
+
+	result := effectiveDNSFromJSON(t, s)
+	assert.Equal(t, "none", result.Source)
+	assert.Empty(t, result.Resolvers)
+	assert.Empty(t, result.MatchDomains)
+}
+
+func TestEffectiveDNS_MobileNebulaIgnored(t *testing.T) {
+	// mobile_nebula DNS settings only exist in pre-v2 configs; MigrateConfigV2
+	// hoists them into dnsOverride and the resolver no longer reads them
+	s := siteJSON(t, map[string]any{
 		"mobile_nebula": map[string]any{
 			"dns_resolvers": []string{"1.1.1.1"},
 			"match_domains": []string{"internal.example.com"},
@@ -80,9 +75,9 @@ func TestEffectiveDNS_EmptyManagedFallsBackToManual(t *testing.T) {
 	}, nil)
 
 	result := effectiveDNSFromJSON(t, s)
-	assert.Equal(t, "manual", result.Source)
-	assert.Equal(t, []string{"1.1.1.1"}, result.Resolvers)
-	assert.Equal(t, []string{"internal.example.com"}, result.MatchDomains)
+	assert.Equal(t, "none", result.Source)
+	assert.Empty(t, result.Resolvers)
+	assert.Empty(t, result.MatchDomains)
 }
 
 func TestEffectiveDNS_OverrideWinsOverManaged(t *testing.T) {
@@ -148,7 +143,7 @@ func TestEffectiveDNS_NoDNSAnywhere(t *testing.T) {
 	s := siteJSON(t, map[string]any{}, nil)
 
 	result := effectiveDNSFromJSON(t, s)
-	assert.Equal(t, "manual", result.Source)
+	assert.Equal(t, "none", result.Source)
 	assert.Empty(t, result.Resolvers)
 	assert.Empty(t, result.MatchDomains)
 	assert.Empty(t, result.SearchDomains)
@@ -157,12 +152,12 @@ func TestEffectiveDNS_NoDNSAnywhere(t *testing.T) {
 func TestEffectiveDNS_EmptyListsMarshalAsArrays(t *testing.T) {
 	out, err := EffectiveDNS(`{"rawConfig": "{}"}`)
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"resolvers": [], "matchDomains": [], "searchDomains": [], "source": "manual"}`, out)
+	assert.JSONEq(t, `{"resolvers": [], "matchDomains": [], "searchDomains": [], "source": "none"}`, out)
 }
 
 func TestEffectiveDNS_MissingRawConfig(t *testing.T) {
 	result := effectiveDNSFromJSON(t, `{}`)
-	assert.Equal(t, "manual", result.Source)
+	assert.Equal(t, "none", result.Source)
 	assert.Empty(t, result.Resolvers)
 }
 
@@ -171,5 +166,110 @@ func TestEffectiveDNS_InvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 
 	_, err = EffectiveDNS(`{"rawConfig": "not json"}`)
+	assert.Error(t, err)
+}
+
+func migrateV2(t *testing.T, siteJSON string) map[string]any {
+	t.Helper()
+	out, err := MigrateConfigV2(siteJSON)
+	require.NoError(t, err)
+	var siteMap map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &siteMap))
+	return siteMap
+}
+
+func rawConfigOf(t *testing.T, siteMap map[string]any) map[string]any {
+	t.Helper()
+	rc, ok := siteMap["rawConfig"].(string)
+	require.True(t, ok)
+	var rawConfig map[string]any
+	require.NoError(t, json.Unmarshal([]byte(rc), &rawConfig))
+	return rawConfig
+}
+
+func TestMigrateConfigV2_MovesDNSToOverride(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"mobile_nebula": map[string]any{
+			"dns_resolvers":  []string{"1.1.1.1"},
+			"match_domains":  []string{"internal.example.com"},
+			"search_domains": []string{"example.com"},
+		},
+	}, map[string]any{"configVersion": 1})
+
+	siteMap := migrateV2(t, s)
+	assert.Equal(t, float64(2), siteMap["configVersion"])
+	assert.Equal(t, map[string]any{
+		"enabled":       true,
+		"resolvers":     []any{"1.1.1.1"},
+		"matchDomains":  []any{"internal.example.com"},
+		"searchDomains": []any{"example.com"},
+	}, siteMap["dnsOverride"])
+
+	// The now-empty mobile_nebula block is removed entirely
+	rawConfig := rawConfigOf(t, siteMap)
+	assert.NotContains(t, rawConfig, "mobile_nebula")
+
+	// The migrated site resolves to the override
+	out, err := json.Marshal(siteMap)
+	require.NoError(t, err)
+	result := effectiveDNSFromJSON(t, string(out))
+	assert.Equal(t, "override", result.Source)
+	assert.Equal(t, []string{"1.1.1.1"}, result.Resolvers)
+}
+
+func TestMigrateConfigV2_KeepsOtherMobileNebulaKeys(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"mobile_nebula": map[string]any{
+			"dns_resolvers": []string{"1.1.1.1"},
+			"future_knob":   "keep",
+		},
+	}, nil)
+
+	siteMap := migrateV2(t, s)
+	rawConfig := rawConfigOf(t, siteMap)
+	assert.Equal(t, map[string]any{"future_knob": "keep"}, rawConfig["mobile_nebula"])
+}
+
+func TestMigrateConfigV2_NoDNSSettings(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"tun": map[string]any{"mtu": 1300},
+	}, nil)
+
+	siteMap := migrateV2(t, s)
+	assert.Equal(t, float64(2), siteMap["configVersion"])
+	assert.NotContains(t, siteMap, "dnsOverride")
+	assert.Equal(t, map[string]any{"mtu": float64(1300)}, rawConfigOf(t, siteMap)["tun"])
+}
+
+func TestMigrateConfigV2_ExistingOverridePreserved(t *testing.T) {
+	s := siteJSON(t, map[string]any{
+		"mobile_nebula": map[string]any{
+			"dns_resolvers": []string{"1.1.1.1"},
+		},
+	}, map[string]any{
+		"dnsOverride": map[string]any{
+			"enabled":   true,
+			"resolvers": []any{"192.168.1.53"},
+		},
+	})
+
+	siteMap := migrateV2(t, s)
+	override, ok := siteMap["dnsOverride"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, []any{"192.168.1.53"}, override["resolvers"])
+	assert.NotContains(t, rawConfigOf(t, siteMap), "mobile_nebula")
+}
+
+func TestMigrateConfigV2_MissingRawConfig(t *testing.T) {
+	siteMap := migrateV2(t, `{"name": "test"}`)
+	assert.Equal(t, float64(2), siteMap["configVersion"])
+	assert.Equal(t, "test", siteMap["name"])
+}
+
+func TestMigrateConfigV2_InvalidJSON(t *testing.T) {
+	_, err := MigrateConfigV2(`not json`)
+	assert.Error(t, err)
+
+	_, err = MigrateConfigV2(`{"rawConfig": "not json"}`)
 	assert.Error(t, err)
 }

--- a/nebula/mobileNebula.go
+++ b/nebula/mobileNebula.go
@@ -232,38 +232,41 @@ func MigrateConfigV2(siteJSON string) (string, error) {
 		return "", fmt.Errorf("failed to parse site JSON: %s", err)
 	}
 
+	// An unparsable rawConfig has nothing to hoist, so skip it rather than fail:
+	// the platform loaders delete a site whose migration errors, while a site
+	// with a bad rawConfig otherwise loads and surfaces a parse error.
 	if rc, ok := siteMap["rawConfig"].(string); ok && rc != "" {
 		var rawConfig map[string]interface{}
-		if err := json.Unmarshal([]byte(rc), &rawConfig); err != nil {
-			return "", fmt.Errorf("failed to parse rawConfig: %s", err)
-		}
-
-		if mn, ok := rawConfig["mobile_nebula"].(map[string]interface{}); ok {
-			resolvers := stringList(mn, "dns_resolvers")
-			matchDomains := stringList(mn, "match_domains")
-			searchDomains := stringList(mn, "search_domains")
-			delete(mn, "dns_resolvers")
-			delete(mn, "match_domains")
-			delete(mn, "search_domains")
-			if len(mn) == 0 {
-				delete(rawConfig, "mobile_nebula")
-			}
-
-			_, hasOverride := siteMap["dnsOverride"]
-			if !hasOverride && (resolvers != nil || matchDomains != nil || searchDomains != nil) {
-				siteMap["dnsOverride"] = map[string]interface{}{
-					"enabled":       true,
-					"resolvers":     orEmpty(resolvers),
-					"matchDomains":  orEmpty(matchDomains),
-					"searchDomains": orEmpty(searchDomains),
+		if err := json.Unmarshal([]byte(rc), &rawConfig); err == nil {
+			if mn, ok := rawConfig["mobile_nebula"].(map[string]interface{}); ok {
+				resolvers := stringList(mn, "dns_resolvers")
+				matchDomains := stringList(mn, "match_domains")
+				searchDomains := stringList(mn, "search_domains")
+				delete(mn, "dns_resolvers")
+				delete(mn, "match_domains")
+				delete(mn, "search_domains")
+				if len(mn) == 0 {
+					delete(rawConfig, "mobile_nebula")
 				}
-			}
 
-			rawConfigBytes, err := json.Marshal(rawConfig)
-			if err != nil {
-				return "", err
+				// A JSON null unmarshals as a present key with a nil value; treat
+				// it as absent so the legacy settings still hoist.
+				hasOverride := siteMap["dnsOverride"] != nil
+				if !hasOverride && (resolvers != nil || matchDomains != nil || searchDomains != nil) {
+					siteMap["dnsOverride"] = map[string]interface{}{
+						"enabled":       true,
+						"resolvers":     orEmpty(resolvers),
+						"matchDomains":  orEmpty(matchDomains),
+						"searchDomains": orEmpty(searchDomains),
+					}
+				}
+
+				rawConfigBytes, err := json.Marshal(rawConfig)
+				if err != nil {
+					return "", err
+				}
+				siteMap["rawConfig"] = string(rawConfigBytes)
 			}
-			siteMap["rawConfig"] = string(rawConfigBytes)
 		}
 	}
 

--- a/nebula/mobileNebula.go
+++ b/nebula/mobileNebula.go
@@ -211,7 +211,7 @@ func MigrateConfig(oldConfigJSON string, key string) (string, error) {
 		LastManagedUpdate: old.LastManagedUpdate,
 		RawConfig:         string(rawConfigBytes),
 		Key:               nil, // Key is stored separately, not in config.json
-		ConfigVersion:     1,
+		ConfigVersion:     1,   // v0 output stays at 1 so the v2 migration still runs
 		DNCredentials:     nil, // DN credentials are stored separately
 	}
 
@@ -221,6 +221,59 @@ func MigrateConfig(oldConfigJSON string, key string) (string, error) {
 	}
 
 	return string(newJSON), nil
+}
+
+// MigrateConfigV2 migrates a site JSON from configVersion 1 to 2: DNS settings
+// move out of the rawConfig mobile_nebula namespace into the top-level
+// dnsOverride client field so they survive managed config updates.
+func MigrateConfigV2(siteJSON string) (string, error) {
+	var siteMap map[string]interface{}
+	if err := json.Unmarshal([]byte(siteJSON), &siteMap); err != nil {
+		return "", fmt.Errorf("failed to parse site JSON: %s", err)
+	}
+
+	if rc, ok := siteMap["rawConfig"].(string); ok && rc != "" {
+		var rawConfig map[string]interface{}
+		if err := json.Unmarshal([]byte(rc), &rawConfig); err != nil {
+			return "", fmt.Errorf("failed to parse rawConfig: %s", err)
+		}
+
+		if mn, ok := rawConfig["mobile_nebula"].(map[string]interface{}); ok {
+			resolvers := stringList(mn, "dns_resolvers")
+			matchDomains := stringList(mn, "match_domains")
+			searchDomains := stringList(mn, "search_domains")
+			delete(mn, "dns_resolvers")
+			delete(mn, "match_domains")
+			delete(mn, "search_domains")
+			if len(mn) == 0 {
+				delete(rawConfig, "mobile_nebula")
+			}
+
+			_, hasOverride := siteMap["dnsOverride"]
+			if !hasOverride && (resolvers != nil || matchDomains != nil || searchDomains != nil) {
+				siteMap["dnsOverride"] = map[string]interface{}{
+					"enabled":       true,
+					"resolvers":     orEmpty(resolvers),
+					"matchDomains":  orEmpty(matchDomains),
+					"searchDomains": orEmpty(searchDomains),
+				}
+			}
+
+			rawConfigBytes, err := json.Marshal(rawConfig)
+			if err != nil {
+				return "", err
+			}
+			siteMap["rawConfig"] = string(rawConfigBytes)
+		}
+	}
+
+	siteMap["configVersion"] = 2
+
+	out, err := json.Marshal(siteMap)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
 }
 
 // DefaultRawConfig returns a JSON string of the default nebula config.

--- a/nebula/site.go
+++ b/nebula/site.go
@@ -65,7 +65,7 @@ func newDNSite(name string, rawCfg []byte, key string, creds keys.Credentials) (
 		LastManagedUpdate: &now,
 		RawConfig:         string(rawConfigBytes),
 		Key:               &key,
-		ConfigVersion:     1,
+		ConfigVersion:     2,
 		DNCredentials: &dnCredentials{
 			HostID:      creds.HostID,
 			PrivateKey:  string(pkm),

--- a/test/models/site_test.dart
+++ b/test/models/site_test.dart
@@ -420,5 +420,33 @@ listen:
         'resolvers': ['192.168.1.53'],
       });
     });
+
+    test('fromYaml hoists legacy mobile_nebula DNS settings', () async {
+      final site = await Site.fromYaml(
+        loadYaml('''
+mobile_nebula:
+  dns_resolvers:
+    - 1.1.1.1
+  match_domains:
+    - internal.example.com
+'''),
+      );
+      expect(site.dnsResolvers, ['1.1.1.1']);
+      expect(site.matchDomains, ['internal.example.com']);
+      expect(site.dnsOverride!['enabled'], true);
+      expect(site.rawConfig.containsKey('mobile_nebula'), false);
+    });
+
+    test('fromYaml keeps other mobile_nebula keys and skips the override when no DNS is set', () async {
+      final site = await Site.fromYaml(
+        loadYaml('''
+mobile_nebula:
+  dns_resolvers: []
+  future_knob: keep
+'''),
+      );
+      expect(site.dnsOverride, isNull);
+      expect(site.rawConfig['mobile_nebula'], {'future_knob': 'keep'});
+    });
   });
 }

--- a/test/models/site_test.dart
+++ b/test/models/site_test.dart
@@ -406,6 +406,35 @@ listen:
       expect(site.toJson().containsKey('dnsOverride'), false);
     });
 
+    test('empty writes without an existing override do not create one', () {
+      // The Advanced screen save path writes these setters unconditionally;
+      // an enabled-empty override would deliberately disable managed DNS
+      final site = Site();
+      site.dnsResolvers = [];
+      site.matchDomains = [];
+      expect(site.dnsOverride, isNull);
+      expect(site.toJson().containsKey('dnsOverride'), false);
+    });
+
+    test('empty writes to an existing override keep it enabled', () {
+      final site = Site();
+      site.dnsResolvers = ['1.1.1.1'];
+      site.dnsResolvers = [];
+      expect(site.dnsOverride!['resolvers'], isEmpty);
+      expect(site.dnsOverride!['enabled'], true);
+    });
+
+    test('effective DNS from the platform is parsed for display', () {
+      final parsed = Site.parseJson({
+        'name': 'site',
+        'id': 'an-id',
+        'dnsResolvers': ['240.0.0.1'],
+        'matchDomains': ['internal.example.com'],
+      });
+      expect(parsed['effectiveDnsResolvers'], ['240.0.0.1']);
+      expect(parsed['effectiveMatchDomains'], ['internal.example.com']);
+    });
+
     test('parsed from site JSON', () {
       final parsed = Site.parseJson({
         'name': 'site',

--- a/test/models/site_test.dart
+++ b/test/models/site_test.dart
@@ -385,4 +385,40 @@ listen:
       expect(rawConfig['cipher'], 'aes');
     });
   });
+
+  group('dnsOverride', () {
+    test('accessors read and write the override, not rawConfig', () {
+      final site = Site();
+      expect(site.dnsResolvers, isEmpty);
+      expect(site.matchDomains, isEmpty);
+
+      site.dnsResolvers = ['1.1.1.1'];
+      site.matchDomains = ['internal.example.com'];
+      expect(site.dnsResolvers, ['1.1.1.1']);
+      expect(site.matchDomains, ['internal.example.com']);
+      expect(site.dnsOverride!['enabled'], true);
+      expect(site.rawConfig, isEmpty);
+      expect(site.toJson()['dnsOverride'], site.dnsOverride);
+    });
+
+    test('omitted from save JSON when unset so the platform preserves any existing override', () {
+      final site = Site();
+      expect(site.toJson().containsKey('dnsOverride'), false);
+    });
+
+    test('parsed from site JSON', () {
+      final parsed = Site.parseJson({
+        'name': 'site',
+        'id': 'an-id',
+        'dnsOverride': {
+          'enabled': true,
+          'resolvers': ['192.168.1.53'],
+        },
+      });
+      expect(parsed['dnsOverride'], {
+        'enabled': true,
+        'resolvers': ['192.168.1.53'],
+      });
+    });
+  });
 }


### PR DESCRIPTION
## What

Moves site DNS resolution into a single Go helper, `EffectiveDNS`, consumed by both platform layers instead of each parsing `rawConfig` on its own. There are exactly two DNS channels:

1. `dnsOverride` - a device-local, client-only site field (preserved across managed config updates, like `excludedApps`/`sortKey`). The explicit `enabled` flag lets a user disable managed DNS on a device without substituting their own resolvers. This is now the only channel for user-configured DNS, on managed and unmanaged sites alike.
2. Managed `definednet.dns` from `rawConfig` - non-empty `resolver_addrs` is the install signal, matching dnclient. Applies only while the override is not enabled.

The helper returns `{resolvers, matchDomains, searchDomains, source}` as JSON; empty lists marshal as `[]` for the platform parsers.

## Migration

The legacy manual channel (`mobile_nebula.dns_resolvers` / `match_domains` / `search_domains` inside `rawConfig`) is dropped. A `configVersion` 2 migration (`MigrateConfigV2` in Go, run by both platform `ConfigMigrator`s on site load) hoists those settings into `dnsOverride` with `enabled: true`, removes the keys, and deletes the `mobile_nebula` block if empty. An existing `dnsOverride` is never clobbered. The v0 to v1 migration still emits `mobile_nebula.dns_resolvers`, so v0 sites migrate through the chain. `saveSite` on both platforms now stamps `configVersion: 2`. YAML imports (`Site.fromYaml`) apply the same hoist, since imported configs never pass through `ConfigMigrator` and are stamped at the current version on save.

## Platform changes

- **Android**: `Site` resolves `dnsResolvers`/`matchDomains`/`searchDomains` via the helper; `NebulaVpnService` applies search domains with `addSearchDomain` and logs a warning when match domains are set, since `VpnService` cannot split DNS by domain. `dnsOverride` is exported to Flutter.
- **iOS**: `Site` resolves through the same helper; `PacketTunnelProvider` now applies `searchDomains` to `NEDNSSettings`. `dnsOverride` is a typed `Codable` struct so it rides along in the `Encodable` output to Flutter.
- **Flutter**: `Site` round-trips `dnsOverride` through save (omitted when unset so the platform preserves any existing override). The `dnsResolvers`/`matchDomains` getters and setters read and write the override instead of `rawConfig`; writing any DNS setting sets `enabled: true`.

## Testing

- `go test ./...` in `nebula/` covers channel precedence, the enabled-but-empty override (deliberately disables DNS), the inert empty managed block, `mobile_nebula.*` being ignored post-migration, and the v2 migration itself (hoist, key removal, preservation of unrelated `mobile_nebula` keys and existing overrides).
- `flutter test` covers the new Dart accessors and save JSON behavior.
- Builds against upstream `slackhq/nebula v1.11.0` with no go.mod changes.
