### PR TITLE
Use our own apple profile downloader

### DIFF
--- a/.github/scripts/asc.py
+++ b/.github/scripts/asc.py
@@ -1,0 +1,80 @@
+"""Shared App Store Connect plumbing: a signed JWT and a JSON request.
+
+No pip dependencies; the JWT signing shells out to openssl, the same shape as
+ansible's bin/apple-certs/cert. Credentials come from ASC_KEY_ID, ASC_ISSUER_ID
+and ASC_PRIVATE_KEY (the .p8 content itself).
+"""
+
+import base64
+import datetime as dt
+import json
+import os
+import subprocess
+import urllib.error
+import urllib.request
+
+# Overridable so the tests can point at a local stand-in. Nothing sets it in CI.
+API = os.environ.get("ASC_API_BASE", "https://api.appstoreconnect.apple.com/v1")
+
+
+class Fatal(Exception):
+    pass
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _der_to_raw(der: bytes) -> bytes:
+    """ECDSA signatures come back DER encoded, JWS wants raw r||s."""
+    if der[0] != 0x30:
+        raise Fatal("signature was not a DER sequence")
+    idx = 2 if der[1] < 0x80 else 2 + (der[1] & 0x7F)
+    out = b""
+    for _ in range(2):
+        if der[idx] != 0x02:
+            raise Fatal("expected a DER integer in the signature")
+        length = der[idx + 1]
+        val = der[idx + 2 : idx + 2 + length]
+        val = val.lstrip(b"\x00").rjust(32, b"\x00")
+        out += val
+        idx += 2 + length
+    return out
+
+
+def token(key_id: str, issuer_id: str, key_path: str) -> str:
+    now = int(dt.datetime.now(dt.timezone.utc).timestamp())
+    header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+    # Apple rejects anything longer than 20 minutes
+    payload = {"iss": issuer_id, "iat": now, "exp": now + 15 * 60, "aud": "appstoreconnect-v1"}
+    signing_input = f"{_b64url(json.dumps(header).encode())}.{_b64url(json.dumps(payload).encode())}"
+    der = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-sign", key_path],
+        input=signing_input.encode(),
+        capture_output=True,
+        check=True,
+    ).stdout
+    return f"{signing_input}.{_b64url(_der_to_raw(der))}"
+
+
+def api(method: str, path: str, auth: str, body=None):
+    req = urllib.request.Request(
+        f"{API}{path}",
+        method=method,
+        data=json.dumps(body).encode() if body else None,
+        headers={"Authorization": f"Bearer {auth}", "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode()
+        try:
+            errors = json.loads(detail).get("errors", [])
+            detail = "; ".join(f"{x.get('title')}: {x.get('detail')}" for x in errors) or detail
+        except json.JSONDecodeError:
+            pass
+        raise Fatal(f"App Store Connect said {e.code}: {detail}")
+    except urllib.error.URLError as e:
+        raise Fatal(f"could not reach App Store Connect: {e.reason}")

--- a/.github/scripts/download-profiles.py
+++ b/.github/scripts/download-profiles.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Download the ACTIVE provisioning profile for each of several bundle ids.
+
+Apple-Actions/download-provisioning-profiles sends `filter[identifier]` unpaged,
+and that filter is a prefix match. net.defined.mobileNebula is the prefix of
+every id in the account, so the app itself, the oldest and shortest, falls off
+the default page of twenty and the step reports it as having no ACTIVE profile.
+
+Kept in step with nebula-apple's copy, which takes several bundle ids at once
+for its system extension slots.
+
+Writes the same files in the same place as the action, so the check that follows
+it and xcodebuild both find what they expect:
+$HOME/Library/MobileDevice/Provisioning Profiles/<uuid>.<provisionprofile|mobileprovision>
+
+Bundle ids come from the arguments, or newline separated on stdin.
+"""
+
+import argparse
+import base64
+import os
+import pathlib
+import sys
+import tempfile
+import urllib.parse
+
+from asc import Fatal, api, token
+
+
+def profiles_for(auth_of, bundle_id: str, profile_type: str) -> list:
+    """Every ACTIVE profile attached to this bundle id, matching profile_type."""
+    # limit=200, Apple's max page. `filter[identifier]` is a prefix match, so net.defined.mobileNebula
+    # comes back with every bundle id that starts with it: prod, beta, debug and all their extensions
+    # and slots, around forty. Without the limit that spills past the default page and the app id we
+    # actually asked for, the oldest and shortest, is not on it, so the exact-match filter below finds
+    # nothing and calls the app id missing when it is only unpaged.
+    query = urllib.parse.urlencode(
+        {"filter[identifier]": bundle_id, "include": "profiles", "limit": 200}
+    )
+    body = api("GET", f"/bundleIds?{query}", auth_of())
+
+    # A full page means there could be more, and the honest fix then is real pagination. Fail loud
+    # rather than silently miss a bundle id that fell off the end.
+    if len(body.get("data", [])) >= 200:
+        raise Fatal(f"more than 200 bundle ids start with '{bundle_id}'; this needs pagination")
+
+    # Exactly this identifier, not the prefix matches above: without this a slot's profile could be
+    # written for the app and the app's for a slot.
+    bundles = [b for b in body.get("data", []) if b.get("attributes", {}).get("identifier") == bundle_id]
+    if not bundles:
+        raise Fatal(f"no App ID registered with bundle id '{bundle_id}'")
+
+    wanted = {rel["id"] for b in bundles for rel in b.get("relationships", {}).get("profiles", {}).get("data", [])}
+    out = []
+    for item in body.get("included", []):
+        if item.get("type") != "profiles" or item["id"] not in wanted:
+            continue
+        attrs = item.get("attributes", {})
+        if attrs.get("profileState") != "ACTIVE":
+            continue
+        if profile_type and attrs.get("profileType") != profile_type:
+            continue
+        out.append(attrs)
+    if not out:
+        raise Fatal(
+            f"no ACTIVE {profile_type or 'any-type'} profile for bundle id '{bundle_id}'. "
+            "Check the App ID exists, that a profile is attached to it, and that the profile has "
+            "not been invalidated by a capability change."
+        )
+    return out
+
+
+def write(attrs: dict, into: pathlib.Path) -> pathlib.Path:
+    uuid = attrs.get("uuid")
+    content = attrs.get("profileContent")
+    if not uuid or not content:
+        raise Fatal(f"profile '{attrs.get('name')}' came back without a uuid or its content")
+    # Same rule the action uses: platform can be absent or UNIVERSAL, so fall back to the type.
+    mac = attrs.get("platform") == "MAC_OS" or (attrs.get("profileType") or "").startswith("MAC_")
+    path = into / f"{uuid}.{'provisionprofile' if mac else 'mobileprovision'}"
+    path.write_bytes(base64.b64decode(content))
+    return path
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("bundle_ids", nargs="*", help="bundle ids; newline separated on stdin if absent")
+    p.add_argument("--profile-type", default="", help="e.g. MAC_APP_STORE, IOS_APP_STORE")
+    args = p.parse_args()
+
+    ids = [b.strip() for b in args.bundle_ids]
+    if not ids and not sys.stdin.isatty():
+        ids = [line.strip() for line in sys.stdin]
+    ids = [b for b in ids if b]
+    if not ids:
+        raise Fatal("no bundle ids given")
+
+    home = os.environ.get("HOME")
+    if not home:
+        raise Fatal("HOME is not set, so there is nowhere to install a profile")
+    into = pathlib.Path(home) / "Library/MobileDevice/Provisioning Profiles"
+    into.mkdir(parents=True, exist_ok=True)
+
+    key_id = os.environ["ASC_KEY_ID"]
+    issuer_id = os.environ["ASC_ISSUER_ID"]
+    key = os.environ["ASC_PRIVATE_KEY"]
+    with tempfile.NamedTemporaryFile("w", suffix=".p8", delete=True) as f:
+        f.write(key)
+        f.flush()
+        # Fresh per call, so twenty slots cannot outlive one token's 15 minutes
+        auth_of = lambda: token(key_id, issuer_id, f.name)  # noqa: E731
+
+        for bundle_id in ids:
+            for attrs in profiles_for(auth_of, bundle_id, args.profile_type):
+                path = write(attrs, into)
+                print(f"wrote '{attrs.get('name')}' for {bundle_id} to {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Fatal as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,25 +174,14 @@ jobs:
           } >> "$GITHUB_ENV"
 
       # Automatic signing wants a cloud managed profile, which Apple refuses here
-      - name: Download the app profile
-        uses: Apple-Actions/download-provisioning-profiles@473562c853e9f580367eeff7c180258653e416e0 #v6.1.0
-        with:
-          bundle-id: net.defined.mobileNebula
-          profile-type: IOS_APP_STORE
-          issuer-id: ${{ env.ASC_ISSUER_ID }}
-          api-key-id: ${{ env.ASC_KEY_ID }}
-          api-private-key: ${{ env.ASC_PRIVATE_KEY }}
+      # Not Apple-Actions': its filter[identifier] is an unpaged prefix match, so our shortest
+      # id falls off page one and reads as having no ACTIVE profile
+      - name: Download the profiles
+        run: |
+          python3 .github/scripts/download-profiles.py --profile-type IOS_APP_STORE \
+            net.defined.mobileNebula \
+            net.defined.mobileNebula.NebulaNetworkExtension
 
-      - name: Download the extension profile
-        uses: Apple-Actions/download-provisioning-profiles@473562c853e9f580367eeff7c180258653e416e0 #v6.1.0
-        with:
-          bundle-id: net.defined.mobileNebula.NebulaNetworkExtension
-          profile-type: IOS_APP_STORE
-          issuer-id: ${{ env.ASC_ISSUER_ID }}
-          api-key-id: ${{ env.ASC_KEY_ID }}
-          api-private-key: ${{ env.ASC_PRIVATE_KEY }}
-
-      # The download action treats no profiles as success
       - name: Check the profiles we need are installed
         run: |
           for want in "apple-signing net.defined.mobileNebula" \


### PR DESCRIPTION
Apple official action breaks if we have more than 20 matching identifiers, quick escape is to not use it.